### PR TITLE
Issue 60

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,9 @@
         "icon_protos.h": "c",
         "dos_protos.h": "c",
         "exec_protos.h": "c",
-        "dos.h": "c"
+        "dos.h": "c",
+        "locale.h": "c",
+        "igamestrings_cat.h": "c",
+        "intuition.h": "c"
     }
 }

--- a/src/iGameGUI.c
+++ b/src/iGameGUI.c
@@ -1,9 +1,9 @@
 /*
   iGameGUI.c
   GUI source for iGame
-  
+
   Copyright (c) 2019, Emmanuel Vasilakis and contributors
-  
+
   This file is part of iGame.
 
   iGame is free software: you can redistribute it and/or modify
@@ -234,7 +234,7 @@ struct ObjApp * CreateApp(void)
 	object->STR_TX_PropertiesTimesPlayed = NULL;
 	object->STR_TX_PropertiesSlavePath = NULL;
 	object->STR_TX_PropertiesTooltypes = NULL;
-	
+
 	char about_text[512];
 	strcpy(about_text, "iGame\n");
 	strcat(about_text, VERSION);
@@ -360,7 +360,7 @@ struct ObjApp * CreateApp(void)
 			Child, object->LV_GamesList,
 			End;
 	}
-	
+
 	object->TX_Status = TextObject,
 		MUIA_Background, MUII_TextBack,
 		MUIA_Frame, MUIV_Frame_Text,
@@ -379,12 +379,12 @@ struct ObjApp * CreateApp(void)
 
 	MNlabelScan = MenuitemObject,
 		MUIA_Menuitem_Title, GetMBString(MSG_MNlabelScan),
-		MUIA_Menuitem_Shortcut, GetMBString(MSG_MNlabelScanChar),
+		MUIA_Menuitem_Shortcut, "R",
 		End;
 
 	MNMainAddnonWHDLoadgame = MenuitemObject,
 		MUIA_Menuitem_Title, GetMBString(MSG_MNMainAddnonWHDLoadgame),
-		MUIA_Menuitem_Shortcut, GetMBString(MSG_MNMainAddnonWHDLoadgameChar),
+		MUIA_Menuitem_Shortcut, "A",
 		End;
 
 	MNMainMenuShowHidehiddenentries = MenuitemObject,
@@ -393,12 +393,12 @@ struct ObjApp * CreateApp(void)
 
 	MNMainOpenList = MenuitemObject,
 		MUIA_Menuitem_Title, GetMBString(MSG_MNMainOpenList),
-		MUIA_Menuitem_Shortcut, GetMBString(MSG_MNMainOpenListChar),
+		MUIA_Menuitem_Shortcut, "O",
 		End;
 
 	MNMainSaveList = MenuitemObject,
 		MUIA_Menuitem_Title, GetMBString(MSG_MNMainSaveList),
-		MUIA_Menuitem_Shortcut, GetMBString(MSG_MNMainSaveListChar),
+		MUIA_Menuitem_Shortcut, "S",
 		End;
 
 	MNMainSaveListAs = MenuitemObject,
@@ -415,7 +415,7 @@ struct ObjApp * CreateApp(void)
 
 	MNMainQuit = MenuitemObject,
 		MUIA_Menuitem_Title, GetMBString(MSG_MNMainQuit),
-		MUIA_Menuitem_Shortcut, GetMBString(MSG_MNMainQuitChar),
+		MUIA_Menuitem_Shortcut, "Q",
 		End;
 
 	MNlabel2Actions = MenuitemObject,
@@ -439,12 +439,12 @@ struct ObjApp * CreateApp(void)
 
 	MNMainProperties = MenuitemObject,
 		MUIA_Menuitem_Title, GetMBString(MSG_MNMainProperties),
-		MUIA_Menuitem_Shortcut, GetMBString(MSG_MNMainPropertiesChar),
+		MUIA_Menuitem_Shortcut, "P",
 		End;
 
 	MNMainDelete = MenuitemObject,
 		MUIA_Menuitem_Title, GetMBString(MSG_MNMainDelete),
-		MUIA_Menuitem_Shortcut, GetMBString(MSG_MNMainDeleteChar),
+		MUIA_Menuitem_Shortcut, "D",
 		End;
 
 	MNlabel2Game = MenuitemObject,


### PR DESCRIPTION
Hardcoded the shortcut characters, as the GetMBString() seems to not work as intended with MUI 5. Also, I don't think the shortcut characters should be translated, for many reasons, like the user might use characters from his own language with unpredictable results.