### PR TITLE
Simplified makefiles using includes for the common parts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,33 +47,14 @@ LIBFLAGS_OS4	= -v -lamiga -lstubs -o
 ##########################################################################
 # Object files which are part of iGame
 ##########################################################################
-OBJS		= src/funcs.o src/iGameGUI.o src/iGameMain.o src/strfuncs.o src/iGame_cat.o
-OBJS_030	= src/funcs_030.o src/iGameGUI_030.o src/iGameMain_030.o src/strfuncs_030.o src/iGame_cat_030.o
-OBJS_040	= src/funcs_040.o src/iGameGUI_040.o src/iGameMain_040.o src/strfuncs_040.o src/iGame_cat_040.o
-OBJS_060	= src/funcs_060.o src/iGameGUI_060.o src/iGameMain_060.o src/strfuncs_060.o src/iGame_cat_060.o
-OBJS_MOS	= src/funcs_MOS.o src/iGameGUI_MOS.o src/iGameMain_MOS.o src/strfuncs_MOS.o src/iGame_cat_MOS.o
-OBJS_OS4	= src/funcs_OS4.o src/iGameGUI_OS4.o src/iGameMain_OS4.o src/strfuncs_OS4.o src/iGame_cat_OS4.o
+
+include make_includes/obj_files.inc
 
 ##########################################################################
 # Rule for building
 ##########################################################################
-iGame: $(OBJS)
-	$(LINK) $(OBJS) $(LIBFLAGS) $@
 
-iGame.030: $(OBJS_030)
-	$(LINK) $(OBJS_030) $(LIBFLAGS) $@
-
-iGame.040: $(OBJS_040)
-	$(LINK) $(OBJS_040) $(LIBFLAGS) $@
-
-iGame.060: $(OBJS_060)
-	$(LINK) $(OBJS_060) $(LIBFLAGS) $@
-
-iGame.MOS: $(OBJS_MOS)
-	$(LINK_PPC) $(OBJS_MOS) $(LIBFLAGS_MOS) $@
-
-iGame.OS4: $(OBJS_OS4)
-	$(LINK_PPC) $(OBJS_OS4) $(LIBFLAGS_OS4) $@
+include make_includes/rules.inc
 
 ##########################################################################
 # catalog files
@@ -95,115 +76,38 @@ catalogs: $(catalog_files)
 ##########################################################################
 # object files (generic 000)
 ##########################################################################
-src/funcs.o: src/funcs.c src/iGame_cat.h src/strfuncs.h
-	$(CC) $(CFLAGS) $(INCLUDES) -o $@ src/funcs.c
 
-src/iGameGUI.o: src/iGameGUI.c src/iGameGUI.h src/version.h src/iGame_cat.h
-	$(CC) $(CFLAGS) $(INCLUDES) -o $@ src/iGameGUI.c
-
-src/iGameMain.o: src/iGameMain.c
-	$(CC) $(CFLAGS) $(INCLUDES) -o $@ src/iGameMain.c
-
-src/strfuncs.o: src/strfuncs.c src/strfuncs.h
-	$(CC) $(CFLAGS) $(INCLUDES) -o $@ src/strfuncs.c
-
-src/iGame_cat.o: src/iGame_cat.c
-	$(CC) $(CFLAGS) $(INCLUDES) -o $@ src/iGame_cat.c
+include make_includes/obj_000.inc
 
 ##########################################################################
 # object files (030)
 ##########################################################################
 
-src/funcs_030.o: src/funcs.c src/iGame_cat.h src/strfuncs.h
-	$(CC) $(CFLAGS_030) $(INCLUDES) -o $@ src/funcs.c
-
-src/iGameGUI_030.o: src/iGameGUI.c src/iGameGUI.h src/iGame_cat.h
-	$(CC) $(CFLAGS_030) $(INCLUDES) -o $@ src/iGameGUI.c
-
-src/iGameMain_030.o: src/iGameMain.c
-	$(CC) $(CFLAGS_030) $(INCLUDES) -o $@ src/iGameMain.c
-
-src/strfuncs_030.o: src/strfuncs.c src/strfuncs.h
-	$(CC) $(CFLAGS_030) $(INCLUDES) -o $@ src/strfuncs.c
-
-src/iGame_cat_030.o: src/iGame_cat.c
-	$(CC) $(CFLAGS_030) $(INCLUDES) -o $@ src/iGame_cat.c
+include make_includes/obj_030.inc
 
 ##########################################################################
 # object files (040)
 ##########################################################################
 
-src/funcs_040.o: src/funcs.c src/iGame_cat.h src/strfuncs.h
-	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/funcs.c
-
-src/iGameGUI_040.o: src/iGameGUI.c src/iGameGUI.h src/iGame_cat.h
-	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/iGameGUI.c
-
-src/iGameMain_040.o: src/iGameMain.c
-	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/iGameMain.c
-
-src/strfuncs_040.o: src/strfuncs.c src/strfuncs.h
-	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/strfuncs.c
-
-src/iGame_cat_040.o: src/iGame_cat.c
-	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/iGame_cat.c
+include make_includes/obj_040.inc
 
 ##########################################################################
 # object files (060)
 ##########################################################################
 
-src/funcs_060.o: src/funcs.c src/iGame_cat.h src/strfuncs.h
-	$(CC) $(CFLAGS_060) $(INCLUDES) -o $@ src/funcs.c
-
-src/iGameGUI_060.o: src/iGameGUI.c src/iGameGUI.h src/iGame_cat.h
-	$(CC) $(CFLAGS_060) $(INCLUDES) -o $@ src/iGameGUI.c
-
-src/iGameMain_060.o: src/iGameMain.c
-	$(CC) $(CFLAGS_060) $(INCLUDES) -o $@ src/iGameMain.c
-
-src/strfuncs_060.o: src/strfuncs.c
-	$(CC) $(CFLAGS_060) $(INCLUDES) -o $@ src/strfuncs.c
-
-src/iGame_cat_060.o: src/iGame_cat.c
-	$(CC) $(CFLAGS_060) $(INCLUDES) -o $@ src/iGame_cat.c
+include make_includes/obj_060.inc
 
 ##########################################################################
 # object files (MOS)
 ##########################################################################
 
-src/funcs_MOS.o: src/funcs.c src/iGame_cat.h src/strfuncs.h
-	$(CC_PPC) $(CFLAGS_MOS) $(INCLUDES_MOS) -o $@ src/funcs.c
-
-src/iGameGUI_MOS.o: src/iGameGUI.c src/iGameGUI.h src/iGame_cat.h
-	$(CC_PPC) $(CFLAGS_MOS) $(INCLUDES_MOS) -o $@ src/iGameGUI.c
-
-src/iGameMain_MOS.o: src/iGameMain.c
-	$(CC_PPC) $(CFLAGS_MOS) $(INCLUDES_MOS) -o $@ src/iGameMain.c
-
-src/strfuncs_MOS.o: src/strfuncs.c src/strfuncs.h
-	$(CC) $(CFLAGS_MOS) $(INCLUDES_MOS) -o $@ src/strfuncs.c
-
-src/iGame_cat_MOS.o: src/iGame_cat.c
-	$(CC_PPC) $(CFLAGS_MOS) $(INCLUDES_MOS) -o $@ src/iGame_cat.c
+include make_includes/obj_mos.inc
 
 ##########################################################################
 # object files (AOS4)
 ##########################################################################
 
-src/funcs_OS4.o: src/funcs.c src/iGame_cat.h src/strfuncs.h
-	$(CC_PPC) $(CFLAGS_OS4) $(INCLUDES_OS4) -o $@ src/funcs.c
-
-src/iGameGUI_OS4.o: src/iGameGUI.c src/iGameGUI.h src/iGame_cat.h
-	$(CC_PPC) $(CFLAGS_OS4) $(INCLUDES_OS4) -o $@ src/iGameGUI.c
-
-src/iGameMain_OS4.o: src/iGameMain.c
-	$(CC_PPC) $(CFLAGS_OS4) $(INCLUDES_OS4) -o $@ src/iGameMain.c
-
-src/strfuncs_OS4.o: src/strfuncs.c src/strfuncs.h
-	$(CC) $(CFLAGS_OS4) $(INCLUDES_OS4) -o $@ src/strfuncs.c
-
-src/iGame_cat_OS4.o: src/iGame_cat.c
-	$(CC_PPC) $(CFLAGS_OS4) $(INCLUDES_OS4) -o $@ src/iGame_cat.c
+include make_includes/obj_os4.inc
 
 ##########################################################################
 # generic build options

--- a/Makefile.Windows.mak
+++ b/Makefile.Windows.mak
@@ -22,6 +22,8 @@ DATE = $(shell date --iso=date)
 ##########################################################################
 CC			= vc
 LINK		= vc
+CC_PPC		= vc
+LINK_PPC	= vc
 
 INCLUDES	= -I$(NDK_INC) -I$(MUI38_INC)
 INCLUDES_OS4= -I$(SDK_INC) -I$(MUI50_INC)
@@ -46,33 +48,13 @@ LIBFLAGS_OS4	= +aosppc -lamiga -lauto -o
 # Object files which are part of iGame
 ##########################################################################
 
-OBJS		= src/funcs.o src/iGameGUI.o src/iGameMain.o src/strfuncs.o src/iGame_cat.o
-OBJS_030	= src/funcs_030.o src/iGameGUI_030.o src/iGameMain_030.o src/strfuncs_030.o src/iGame_cat_030.o
-OBJS_040	= src/funcs_040.o src/iGameGUI_040.o src/iGameMain_040.o src/strfuncs_040.o src/iGame_cat_040.o
-OBJS_060	= src/funcs_060.o src/iGameGUI_060.o src/iGameMain_060.o src/strfuncs_060.o src/iGame_cat_060.o
-OBJS_MOS	= src/funcs_MOS.o src/iGameGUI_MOS.o src/iGameMain_MOS.o src/strfuncs_MOS.o src/iGame_cat_MOS.o
-OBJS_OS4	= src/funcs_OS4.o src/iGameGUI_OS4.o src/iGameMain_OS4.o src/strfuncs_OS4.o src/iGame_cat_OS4.o
+include make_includes/obj_files.inc
 
 ##########################################################################
 # Rule for building
 ##########################################################################
-iGame: $(OBJS)
-	$(LINK) $(OBJS) $(LIBFLAGS) $@
 
-iGame.030: $(OBJS_030)
-	$(LINK) $(OBJS_030) $(LIBFLAGS) $@
-
-iGame.040: $(OBJS_040)
-	$(LINK) $(OBJS_040) $(LIBFLAGS) $@
-
-iGame.060: $(OBJS_060)
-	$(LINK) $(OBJS_060) $(LIBFLAGS) $@
-
-iGame.MOS: $(OBJS_MOS)
-	$(LINK) $(OBJS_MOS) $(LIBFLAGS_MOS) $@
-
-iGame.OS4: $(OBJS_OS4)
-	$(LINK) $(OBJS_OS4) $(LIBFLAGS_OS4) $@
+include make_includes/rules.inc
 
 ##########################################################################
 # catalog files
@@ -93,115 +75,38 @@ catalogs: $(catalog_files)
 ##########################################################################
 # object files (generic 000)
 ##########################################################################
-src/funcs.o: src/funcs.c src/iGame_cat.h src/strfuncs.h
-	$(CC) $(CFLAGS) $(INCLUDES) -o $@ src/funcs.c
 
-src/iGameGUI.o: src/iGameGUI.c src/iGameGUI.h src/version.h src/iGame_cat.h
-	$(CC) $(CFLAGS) $(INCLUDES) -o $@ src/iGameGUI.c
-
-src/iGameMain.o: src/iGameMain.c
-	$(CC) $(CFLAGS) $(INCLUDES) -o $@ src/iGameMain.c
-
-src/strfuncs.o: src/strfuncs.c src/strfuncs.h
-	$(CC) $(CFLAGS) $(INCLUDES) -o $@ src/strfuncs.c
-
-src/iGame_cat.o: src/iGame_cat.c
-	$(CC) $(CFLAGS) $(INCLUDES) -o $@ src/iGame_cat.c
+include make_includes/obj_000.inc
 
 ##########################################################################
 # object files (030)
 ##########################################################################
 
-src/funcs_030.o: src/funcs.c src/iGame_cat.h src/strfuncs.h
-	$(CC) $(CFLAGS_030) $(INCLUDES) -o $@ src/funcs.c
-
-src/iGameGUI_030.o: src/iGameGUI.c src/iGameGUI.h src/iGame_cat.h
-	$(CC) $(CFLAGS_030) $(INCLUDES) -o $@ src/iGameGUI.c
-
-src/iGameMain_030.o: src/iGameMain.c
-	$(CC) $(CFLAGS_030) $(INCLUDES) -o $@ src/iGameMain.c
-
-src/strfuncs_030.o: src/strfuncs.c src/strfuncs.h
-	$(CC) $(CFLAGS_030) $(INCLUDES) -o $@ src/strfuncs.c
-
-src/iGame_cat_030.o: src/iGame_cat.c
-	$(CC) $(CFLAGS_030) $(INCLUDES) -o $@ src/iGame_cat.c
+include make_includes/obj_030.inc
 
 ##########################################################################
 # object files (040)
 ##########################################################################
 
-src/funcs_040.o: src/funcs.c src/iGame_cat.h src/strfuncs.h
-	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/funcs.c
-
-src/iGameGUI_040.o: src/iGameGUI.c src/iGameGUI.h src/iGame_cat.h
-	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/iGameGUI.c
-
-src/iGameMain_040.o: src/iGameMain.c
-	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/iGameMain.c
-
-src/strfuncs_040.o: src/strfuncs.c src/strfuncs.h
-	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/strfuncs.c
-
-src/iGame_cat_040.o: src/iGame_cat.c
-	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/iGame_cat.c
+include make_includes/obj_040.inc
 
 ##########################################################################
 # object files (060)
 ##########################################################################
 
-src/funcs_060.o: src/funcs.c src/iGame_cat.h src/strfuncs.h
-	$(CC) $(CFLAGS_060) $(INCLUDES) -o $@ src/funcs.c
-
-src/iGameGUI_060.o: src/iGameGUI.c src/iGameGUI.h src/iGame_cat.h
-	$(CC) $(CFLAGS_060) $(INCLUDES) -o $@ src/iGameGUI.c
-
-src/iGameMain_060.o: src/iGameMain.c
-	$(CC) $(CFLAGS_060) $(INCLUDES) -o $@ src/iGameMain.c
-
-src/strfuncs_060.o: src/strfuncs.c
-	$(CC) $(CFLAGS_060) $(INCLUDES) -o $@ src/strfuncs.c
-
-src/iGame_cat_060.o: src/iGame_cat.c
-	$(CC) $(CFLAGS_060) $(INCLUDES) -o $@ src/iGame_cat.c
+include make_includes/obj_060.inc
 
 ##########################################################################
 # object files (MOS)
 ##########################################################################
 
-src/funcs_MOS.o: src/funcs.c src/iGame_cat.h src/strfuncs.h
-	$(CC) $(CFLAGS_MOS) $(INCLUDES_MOS) -o $@ src/funcs.c
-
-src/iGameGUI_MOS.o: src/iGameGUI.c src/iGameGUI.h src/iGame_cat.h
-	$(CC) $(CFLAGS_MOS) $(INCLUDES_MOS) -o $@ src/iGameGUI.c
-
-src/iGameMain_MOS.o: src/iGameMain.c
-	$(CC) $(CFLAGS_MOS) $(INCLUDES_MOS) -o $@ src/iGameMain.c
-
-src/strfuncs_MOS.o: src/strfuncs.c src/strfuncs.h
-	$(CC) $(CFLAGS_MOS) $(INCLUDES_MOS) -o $@ src/strfuncs.c
-
-src/iGame_cat_MOS.o: src/iGame_cat.c
-	$(CC) $(CFLAGS_MOS) $(INCLUDES_MOS) -o $@ src/iGame_cat.c
+include make_includes/obj_mos.inc
 
 ##########################################################################
 # object files (AOS4)
 ##########################################################################
 
-src/funcs_OS4.o: src/funcs.c src/iGame_cat.h src/strfuncs.h
-	$(CC) $(CFLAGS_OS4) $(INCLUDES_OS4) -o $@ src/funcs.c
-
-src/iGameGUI_OS4.o: src/iGameGUI.c src/iGameGUI.h src/iGame_cat.h
-	$(CC) $(CFLAGS_OS4) $(INCLUDES_OS4) -o $@ src/iGameGUI.c
-
-src/iGameMain_OS4.o: src/iGameMain.c
-	$(CC) $(CFLAGS_OS4) $(INCLUDES_OS4) -o $@ src/iGameMain.c
-
-src/strfuncs_OS4.o: src/strfuncs.c src/strfuncs.h
-	$(CC) $(CFLAGS_OS4) $(INCLUDES_OS4) -o $@ src/strfuncs.c
-
-src/iGame_cat_OS4.o: src/iGame_cat.c
-	$(CC) $(CFLAGS_OS4) $(INCLUDES_OS4) -o $@ src/iGame_cat.c
+include make_includes/obj_os4.inc
 
 ##########################################################################
 # generic build options

--- a/Makefile.amigaos
+++ b/Makefile.amigaos
@@ -22,6 +22,8 @@ DATE = $(shell date --iso=date)
 ##########################################################################
 CC			= vc
 LINK		= vc
+CC_PPC		= vc
+LINK_PPC	= vc
 
 INCLUDES_COMMON	= -IDevkits:sdk/classic/MCC_Guigfx/Developer/C/Include -IDevkits:sdk/classic/MCC_Texteditor/Developer/C/Include
 INCLUDES	= -IDevkits:sdk/classic/ndk_39/include/include_h -IDevkits:sdk/classic/MUI/Developer/C/Include $(INCLUDES_COMMON)
@@ -46,33 +48,14 @@ LIBFLAGS_OS4	= +aosppc -lamiga -lauto -o
 ##########################################################################
 # Object files which are part of iGame
 ##########################################################################
-OBJS		= src/funcs.o src/iGameGUI.o src/iGameMain.o src/strfuncs.o src/iGame_cat.o
-OBJS_030	= src/funcs_030.o src/iGameGUI_030.o src/iGameMain_030.o src/strfuncs_030.o src/iGame_cat_030.o
-OBJS_040	= src/funcs_040.o src/iGameGUI_040.o src/iGameMain_040.o src/strfuncs_040.o src/iGame_cat_040.o
-OBJS_060	= src/funcs_060.o src/iGameGUI_060.o src/iGameMain_060.o src/strfuncs_060.o src/iGame_cat_060.o
-OBJS_MOS	= src/funcs_MOS.o src/iGameGUI_MOS.o src/iGameMain_MOS.o src/strfuncs_MOS.o src/iGame_cat_MOS.o
-OBJS_OS4	= src/funcs_OS4.o src/iGameGUI_OS4.o src/iGameMain_OS4.o src/strfuncs_OS4.o src/iGame_cat_OS4.o
+
+include make_includes/obj_files.inc
 
 ##########################################################################
 # Rule for building
 ##########################################################################
-iGame: $(OBJS)
-	$(LINK) $(OBJS) $(LIBFLAGS) $@
 
-iGame.030: $(OBJS_030)
-	$(LINK) $(OBJS_030) $(LIBFLAGS) $@
-
-iGame.040: $(OBJS_040)
-	$(LINK) $(OBJS_040) $(LIBFLAGS) $@
-
-iGame.060: $(OBJS_060)
-	$(LINK) $(OBJS_060) $(LIBFLAGS) $@
-
-iGame.MOS: $(OBJS_MOS)
-	$(LINK) $(OBJS_MOS) $(LIBFLAGS_MOS) $@
-
-iGame.OS4: $(OBJS_OS4)
-	$(LINK) $(OBJS_OS4) $(LIBFLAGS_OS4) $@
+include make_includes/rules.inc
 
 ##########################################################################
 # Rules for generating catalog files
@@ -93,115 +76,38 @@ catalogs: $(catalog_files)
 ##########################################################################
 # object files (generic 000)
 ##########################################################################
-src/funcs.o: src/funcs.c src/iGame_cat.h src/strfuncs.h
-	$(CC) $(CFLAGS) $(INCLUDES) -o $@ src/funcs.c
 
-src/iGameGUI.o: src/iGameGUI.c src/iGameGUI.h src/version.h src/iGame_cat.h
-	$(CC) $(CFLAGS) $(INCLUDES) -o $@ src/iGameGUI.c
-
-src/iGameMain.o: src/iGameMain.c
-	$(CC) $(CFLAGS) $(INCLUDES) -o $@ src/iGameMain.c
-
-src/strfuncs.o: src/strfuncs.c src/strfuncs.h
-	$(CC) $(CFLAGS) $(INCLUDES) -o $@ src/strfuncs.c
-
-src/iGame_cat.o: src/iGame_cat.c
-	$(CC) $(CFLAGS) $(INCLUDES) -o $@ src/iGame_cat.c
+include make_includes/obj_000.inc
 
 ##########################################################################
 # object files (030)
 ##########################################################################
 
-src/funcs_030.o: src/funcs.c src/iGame_cat.h src/strfuncs.h
-	$(CC) $(CFLAGS_030) $(INCLUDES) -o $@ src/funcs.c
-
-src/iGameGUI_030.o: src/iGameGUI.c src/iGameGUI.h src/iGame_cat.h
-	$(CC) $(CFLAGS_030) $(INCLUDES) -o $@ src/iGameGUI.c
-
-src/iGameMain_030.o: src/iGameMain.c
-	$(CC) $(CFLAGS_030) $(INCLUDES) -o $@ src/iGameMain.c
-
-src/strfuncs_030.o: src/strfuncs.c src/strfuncs.h
-	$(CC) $(CFLAGS_030) $(INCLUDES) -o $@ src/strfuncs.c
-
-src/iGame_cat_030.o: src/iGame_cat.c
-	$(CC) $(CFLAGS_030) $(INCLUDES) -o $@ src/iGame_cat.c
+include make_includes/obj_030.inc
 
 ##########################################################################
 # object files (040)
 ##########################################################################
 
-src/funcs_040.o: src/funcs.c src/iGame_cat.h src/strfuncs.h
-	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/funcs.c
-
-src/iGameGUI_040.o: src/iGameGUI.c src/iGameGUI.h src/iGame_cat.h
-	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/iGameGUI.c
-
-src/iGameMain_040.o: src/iGameMain.c
-	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/iGameMain.c
-
-src/strfuncs_040.o: src/strfuncs.c src/strfuncs.h
-	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/strfuncs.c
-
-src/iGame_cat_040.o: src/iGame_cat.c
-	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/iGame_cat.c
+include make_includes/obj_040.inc
 
 ##########################################################################
 # object files (060)
 ##########################################################################
 
-src/funcs_060.o: src/funcs.c src/iGame_cat.h src/strfuncs.h
-	$(CC) $(CFLAGS_060) $(INCLUDES) -o $@ src/funcs.c
-
-src/iGameGUI_060.o: src/iGameGUI.c src/iGameGUI.h src/iGame_cat.h
-	$(CC) $(CFLAGS_060) $(INCLUDES) -o $@ src/iGameGUI.c
-
-src/iGameMain_060.o: src/iGameMain.c
-	$(CC) $(CFLAGS_060) $(INCLUDES) -o $@ src/iGameMain.c
-
-src/strfuncs_060.o: src/strfuncs.c
-	$(CC) $(CFLAGS_060) $(INCLUDES) -o $@ src/strfuncs.c
-
-src/iGame_cat_060.o: src/iGame_cat.c
-	$(CC) $(CFLAGS_060) $(INCLUDES) -o $@ src/iGame_cat.c
+include make_includes/obj_060.inc
 
 ##########################################################################
 # object files (MOS)
 ##########################################################################
 
-src/funcs_MOS.o: src/funcs.c src/iGame_cat.h src/strfuncs.h
-	$(CC) $(CFLAGS_MOS) $(INCLUDES_MOS) -o $@ src/funcs.c
-
-src/iGameGUI_MOS.o: src/iGameGUI.c src/iGameGUI.h src/iGame_cat.h
-	$(CC) $(CFLAGS_MOS) $(INCLUDES_MOS) -o $@ src/iGameGUI.c
-
-src/iGameMain_MOS.o: src/iGameMain.c
-	$(CC) $(CFLAGS_MOS) $(INCLUDES_MOS) -o $@ src/iGameMain.c
-
-src/strfuncs_MOS.o: src/strfuncs.c src/strfuncs.h
-	$(CC) $(CFLAGS_MOS) $(INCLUDES_MOS) -o $@ src/strfuncs.c
-
-src/iGame_cat_MOS.o: src/iGame_cat.c
-	$(CC) $(CFLAGS_MOS) $(INCLUDES_MOS) -o $@ src/iGame_cat.c
+include make_includes/obj_mos.inc
 
 ##########################################################################
 # object files (AOS4)
 ##########################################################################
 
-src/funcs_OS4.o: src/funcs.c src/iGame_cat.h src/strfuncs.h
-	$(CC) $(CFLAGS_OS4) $(INCLUDES_OS4) -o $@ src/funcs.c
-
-src/iGameGUI_OS4.o: src/iGameGUI.c src/iGameGUI.h src/iGame_cat.h
-	$(CC) $(CFLAGS_OS4) $(INCLUDES_OS4) -o $@ src/iGameGUI.c
-
-src/iGameMain_OS4.o: src/iGameMain.c
-	$(CC) $(CFLAGS_OS4) $(INCLUDES_OS4) -o $@ src/iGameMain.c
-
-src/strfuncs_OS4.o: src/strfuncs.c src/strfuncs.h
-	$(CC) $(CFLAGS_OS4) $(INCLUDES_OS4) -o $@ src/strfuncs.c
-
-src/iGame_cat_OS4.o: src/iGame_cat.c
-	$(CC) $(CFLAGS_OS4) $(INCLUDES_OS4) -o $@ src/iGame_cat.c
+include make_includes/obj_os4.inc
 
 ##########################################################################
 # generic build options

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -1,8 +1,8 @@
 ##########################################################################
-# Makefile for iGame on Linux using VBCC.
+# Makefile for iGame on Docker VBCC images.
 #-------------------------------------------------------------------------
 # To compile an iGame flat executable  using this makefile, run:
-#  make -f Makefile.linux
+#  make -f Makefile.docker
 #-------------------------------------------------------------------------
 ##########################################################################
 
@@ -47,6 +47,8 @@ endif
 ##########################################################################
 CC			= vc
 LINK		= vc
+CC_PPC		= vc
+LINK_PPC	= vc
 
 INCLUDES	= -I$(NDK_INC) -I$(MUI38_INC)
 INCLUDES_OS4= -I$(AOS4_SDK_INC) -I$(MUI50_INC)
@@ -70,33 +72,14 @@ LIBFLAGS_OS4	= +aosppc -lamiga -lauto -o
 ##########################################################################
 # Object files which are part of iGame
 ##########################################################################
-OBJS		= src/funcs.o src/iGameGUI.o src/iGameMain.o src/strfuncs.o src/iGame_cat.o
-OBJS_030	= src/funcs_030.o src/iGameGUI_030.o src/iGameMain_030.o src/strfuncs_030.o src/iGame_cat_030.o
-OBJS_040	= src/funcs_040.o src/iGameGUI_040.o src/iGameMain_040.o src/strfuncs_040.o src/iGame_cat_040.o
-OBJS_060	= src/funcs_060.o src/iGameGUI_060.o src/iGameMain_060.o src/strfuncs_060.o src/iGame_cat_060.o
-OBJS_MOS	= src/funcs_MOS.o src/iGameGUI_MOS.o src/iGameMain_MOS.o src/strfuncs_MOS.o src/iGame_cat_MOS.o
-OBJS_OS4	= src/funcs_OS4.o src/iGameGUI_OS4.o src/iGameMain_OS4.o src/strfuncs_OS4.o src/iGame_cat_OS4.o
+
+include make_includes/obj_files.inc
 
 ##########################################################################
 # Rule for building
 ##########################################################################
-iGame: $(OBJS)
-	$(LINK) $(OBJS) $(LIBFLAGS) $@
 
-iGame.030: $(OBJS_030)
-	$(LINK) $(OBJS_030) $(LIBFLAGS) $@
-
-iGame.040: $(OBJS_040)
-	$(LINK) $(OBJS_040) $(LIBFLAGS) $@
-
-iGame.060: $(OBJS_060)
-	$(LINK) $(OBJS_060) $(LIBFLAGS) $@
-
-iGame.MOS: $(OBJS_MOS)
-	$(LINK) $(OBJS_MOS) $(LIBFLAGS_MOS) $@
-
-iGame.OS4: $(OBJS_OS4)
-	$(LINK) $(OBJS_OS4) $(LIBFLAGS_OS4) $@
+include make_includes/rules.inc
 
 ##########################################################################
 # catalog files
@@ -118,115 +101,38 @@ catalogs: $(catalog_files)
 ##########################################################################
 # object files (generic 000)
 ##########################################################################
-src/funcs.o: src/funcs.c src/iGame_cat.h src/strfuncs.h
-	$(CC) $(CFLAGS) $(INCLUDES) -o $@ src/funcs.c
 
-src/iGameGUI.o: src/iGameGUI.c src/iGameGUI.h src/version.h src/iGame_cat.h
-	$(CC) $(CFLAGS) $(INCLUDES) -o $@ src/iGameGUI.c
-
-src/iGameMain.o: src/iGameMain.c
-	$(CC) $(CFLAGS) $(INCLUDES) -o $@ src/iGameMain.c
-
-src/strfuncs.o: src/strfuncs.c src/strfuncs.h
-	$(CC) $(CFLAGS) $(INCLUDES) -o $@ src/strfuncs.c
-
-src/iGame_cat.o: src/iGame_cat.c
-	$(CC) $(CFLAGS) $(INCLUDES) -o $@ src/iGame_cat.c
+include make_includes/obj_000.inc
 
 ##########################################################################
 # object files (030)
 ##########################################################################
 
-src/funcs_030.o: src/funcs.c src/iGame_cat.h src/strfuncs.h
-	$(CC) $(CFLAGS_030) $(INCLUDES) -o $@ src/funcs.c
-
-src/iGameGUI_030.o: src/iGameGUI.c src/iGameGUI.h src/iGame_cat.h
-	$(CC) $(CFLAGS_030) $(INCLUDES) -o $@ src/iGameGUI.c
-
-src/iGameMain_030.o: src/iGameMain.c
-	$(CC) $(CFLAGS_030) $(INCLUDES) -o $@ src/iGameMain.c
-
-src/strfuncs_030.o: src/strfuncs.c src/strfuncs.h
-	$(CC) $(CFLAGS_030) $(INCLUDES) -o $@ src/strfuncs.c
-
-src/iGame_cat_030.o: src/iGame_cat.c
-	$(CC) $(CFLAGS_030) $(INCLUDES) -o $@ src/iGame_cat.c
+include make_includes/obj_030.inc
 
 ##########################################################################
 # object files (040)
 ##########################################################################
 
-src/funcs_040.o: src/funcs.c src/iGame_cat.h src/strfuncs.h
-	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/funcs.c
-
-src/iGameGUI_040.o: src/iGameGUI.c src/iGameGUI.h src/iGame_cat.h
-	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/iGameGUI.c
-
-src/iGameMain_040.o: src/iGameMain.c
-	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/iGameMain.c
-
-src/strfuncs_040.o: src/strfuncs.c src/strfuncs.h
-	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/strfuncs.c
-
-src/iGame_cat_040.o: src/iGame_cat.c
-	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/iGame_cat.c
+include make_includes/obj_040.inc
 
 ##########################################################################
 # object files (060)
 ##########################################################################
 
-src/funcs_060.o: src/funcs.c src/iGame_cat.h src/strfuncs.h
-	$(CC) $(CFLAGS_060) $(INCLUDES) -o $@ src/funcs.c
-
-src/iGameGUI_060.o: src/iGameGUI.c src/iGameGUI.h src/iGame_cat.h
-	$(CC) $(CFLAGS_060) $(INCLUDES) -o $@ src/iGameGUI.c
-
-src/iGameMain_060.o: src/iGameMain.c
-	$(CC) $(CFLAGS_060) $(INCLUDES) -o $@ src/iGameMain.c
-
-src/strfuncs_060.o: src/strfuncs.c
-	$(CC) $(CFLAGS_060) $(INCLUDES) -o $@ src/strfuncs.c
-
-src/iGame_cat_060.o: src/iGame_cat.c
-	$(CC) $(CFLAGS_060) $(INCLUDES) -o $@ src/iGame_cat.c
+include make_includes/obj_060.inc
 
 ##########################################################################
 # object files (MOS)
 ##########################################################################
 
-src/funcs_MOS.o: src/funcs.c src/iGame_cat.h src/strfuncs.h
-	$(CC) $(CFLAGS_MOS) $(INCLUDES_MOS) -o $@ src/funcs.c
-
-src/iGameGUI_MOS.o: src/iGameGUI.c src/iGameGUI.h src/iGame_cat.h
-	$(CC) $(CFLAGS_MOS) $(INCLUDES_MOS) -o $@ src/iGameGUI.c
-
-src/iGameMain_MOS.o: src/iGameMain.c
-	$(CC) $(CFLAGS_MOS) $(INCLUDES_MOS) -o $@ src/iGameMain.c
-
-src/strfuncs_MOS.o: src/strfuncs.c src/strfuncs.h
-	$(CC) $(CFLAGS_MOS) $(INCLUDES_MOS) -o $@ src/strfuncs.c
-
-src/iGame_cat_MOS.o: src/iGame_cat.c
-	$(CC) $(CFLAGS_MOS) $(INCLUDES_MOS) -o $@ src/iGame_cat.c
+include make_includes/obj_mos.inc
 
 ##########################################################################
 # object files (AOS4)
 ##########################################################################
 
-src/funcs_OS4.o: src/funcs.c src/iGame_cat.h src/strfuncs.h
-	$(CC) $(CFLAGS_OS4) $(INCLUDES_OS4) -o $@ src/funcs.c
-
-src/iGameGUI_OS4.o: src/iGameGUI.c src/iGameGUI.h src/iGame_cat.h
-	$(CC) $(CFLAGS_OS4) $(INCLUDES_OS4) -o $@ src/iGameGUI.c
-
-src/iGameMain_OS4.o: src/iGameMain.c
-	$(CC) $(CFLAGS_OS4) $(INCLUDES_OS4) -o $@ src/iGameMain.c
-
-src/strfuncs_OS4.o: src/strfuncs.c src/strfuncs.h
-	$(CC) $(CFLAGS_OS4) $(INCLUDES_OS4) -o $@ src/strfuncs.c
-
-src/iGame_cat_OS4.o: src/iGame_cat.c
-	$(CC) $(CFLAGS_OS4) $(INCLUDES_OS4) -o $@ src/iGame_cat.c
+include make_includes/obj_os4.inc
 
 ##########################################################################
 # generic build options

--- a/Makefile.linux
+++ b/Makefile.linux
@@ -22,6 +22,8 @@ DATE = $(shell date --iso=date)
 ##########################################################################
 CC			= vc
 LINK		= vc
+CC_PPC		= vc
+LINK_PPC	= vc
 
 INCLUDES	= -I$(NDK_INC) -I$(MUI38_INC)
 INCLUDES_OS4= -I$(SDK_INC) -I$(MUI50_INC)
@@ -45,33 +47,14 @@ LIBFLAGS_OS4	= +aosppc -lamiga -lauto -o
 ##########################################################################
 # Object files which are part of iGame
 ##########################################################################
-OBJS		= src/funcs.o src/iGameGUI.o src/iGameMain.o src/strfuncs.o src/iGame_cat.o
-OBJS_030	= src/funcs_030.o src/iGameGUI_030.o src/iGameMain_030.o src/strfuncs_030.o src/iGame_cat_030.o
-OBJS_040	= src/funcs_040.o src/iGameGUI_040.o src/iGameMain_040.o src/strfuncs_040.o src/iGame_cat_040.o
-OBJS_060	= src/funcs_060.o src/iGameGUI_060.o src/iGameMain_060.o src/strfuncs_060.o src/iGame_cat_060.o
-OBJS_MOS	= src/funcs_MOS.o src/iGameGUI_MOS.o src/iGameMain_MOS.o src/strfuncs_MOS.o src/iGame_cat_MOS.o
-OBJS_OS4	= src/funcs_OS4.o src/iGameGUI_OS4.o src/iGameMain_OS4.o src/strfuncs_OS4.o src/iGame_cat_OS4.o
+
+include make_includes/obj_files.inc
 
 ##########################################################################
 # Rule for building
 ##########################################################################
-iGame: $(OBJS)
-	$(LINK) $(OBJS) $(LIBFLAGS) $@
 
-iGame.030: $(OBJS_030)
-	$(LINK) $(OBJS_030) $(LIBFLAGS) $@
-
-iGame.040: $(OBJS_040)
-	$(LINK) $(OBJS_040) $(LIBFLAGS) $@
-
-iGame.060: $(OBJS_060)
-	$(LINK) $(OBJS_060) $(LIBFLAGS) $@
-
-iGame.MOS: $(OBJS_MOS)
-	$(LINK) $(OBJS_MOS) $(LIBFLAGS_MOS) $@
-
-iGame.OS4: $(OBJS_OS4)
-	$(LINK) $(OBJS_OS4) $(LIBFLAGS_OS4) $@
+include make_includes/rules.inc
 
 ##########################################################################
 # catalog files
@@ -93,115 +76,38 @@ catalogs: $(catalog_files)
 ##########################################################################
 # object files (generic 000)
 ##########################################################################
-src/funcs.o: src/funcs.c src/iGame_cat.h src/strfuncs.h
-	$(CC) $(CFLAGS) $(INCLUDES) -o $@ src/funcs.c
 
-src/iGameGUI.o: src/iGameGUI.c src/iGameGUI.h src/version.h src/iGame_cat.h
-	$(CC) $(CFLAGS) $(INCLUDES) -o $@ src/iGameGUI.c
-
-src/iGameMain.o: src/iGameMain.c
-	$(CC) $(CFLAGS) $(INCLUDES) -o $@ src/iGameMain.c
-
-src/strfuncs.o: src/strfuncs.c src/strfuncs.h
-	$(CC) $(CFLAGS) $(INCLUDES) -o $@ src/strfuncs.c
-
-src/iGame_cat.o: src/iGame_cat.c
-	$(CC) $(CFLAGS) $(INCLUDES) -o $@ src/iGame_cat.c
+include make_includes/obj_000.inc
 
 ##########################################################################
 # object files (030)
 ##########################################################################
 
-src/funcs_030.o: src/funcs.c src/iGame_cat.h src/strfuncs.h
-	$(CC) $(CFLAGS_030) $(INCLUDES) -o $@ src/funcs.c
-
-src/iGameGUI_030.o: src/iGameGUI.c src/iGameGUI.h src/iGame_cat.h
-	$(CC) $(CFLAGS_030) $(INCLUDES) -o $@ src/iGameGUI.c
-
-src/iGameMain_030.o: src/iGameMain.c
-	$(CC) $(CFLAGS_030) $(INCLUDES) -o $@ src/iGameMain.c
-
-src/strfuncs_030.o: src/strfuncs.c src/strfuncs.h
-	$(CC) $(CFLAGS_030) $(INCLUDES) -o $@ src/strfuncs.c
-
-src/iGame_cat_030.o: src/iGame_cat.c
-	$(CC) $(CFLAGS_030) $(INCLUDES) -o $@ src/iGame_cat.c
+include make_includes/obj_030.inc
 
 ##########################################################################
 # object files (040)
 ##########################################################################
 
-src/funcs_040.o: src/funcs.c src/iGame_cat.h src/strfuncs.h
-	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/funcs.c
-
-src/iGameGUI_040.o: src/iGameGUI.c src/iGameGUI.h src/iGame_cat.h
-	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/iGameGUI.c
-
-src/iGameMain_040.o: src/iGameMain.c
-	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/iGameMain.c
-
-src/strfuncs_040.o: src/strfuncs.c src/strfuncs.h
-	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/strfuncs.c
-
-src/iGame_cat_040.o: src/iGame_cat.c
-	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/iGame_cat.c
+include make_includes/obj_040.inc
 
 ##########################################################################
 # object files (060)
 ##########################################################################
 
-src/funcs_060.o: src/funcs.c src/iGame_cat.h src/strfuncs.h
-	$(CC) $(CFLAGS_060) $(INCLUDES) -o $@ src/funcs.c
-
-src/iGameGUI_060.o: src/iGameGUI.c src/iGameGUI.h src/iGame_cat.h
-	$(CC) $(CFLAGS_060) $(INCLUDES) -o $@ src/iGameGUI.c
-
-src/iGameMain_060.o: src/iGameMain.c
-	$(CC) $(CFLAGS_060) $(INCLUDES) -o $@ src/iGameMain.c
-
-src/strfuncs_060.o: src/strfuncs.c
-	$(CC) $(CFLAGS_060) $(INCLUDES) -o $@ src/strfuncs.c
-
-src/iGame_cat_060.o: src/iGame_cat.c
-	$(CC) $(CFLAGS_060) $(INCLUDES) -o $@ src/iGame_cat.c
+include make_includes/obj_060.inc
 
 ##########################################################################
 # object files (MOS)
 ##########################################################################
 
-src/funcs_MOS.o: src/funcs.c src/iGame_cat.h src/strfuncs.h
-	$(CC) $(CFLAGS_MOS) $(INCLUDES_MOS) -o $@ src/funcs.c
-
-src/iGameGUI_MOS.o: src/iGameGUI.c src/iGameGUI.h src/iGame_cat.h
-	$(CC) $(CFLAGS_MOS) $(INCLUDES_MOS) -o $@ src/iGameGUI.c
-
-src/iGameMain_MOS.o: src/iGameMain.c
-	$(CC) $(CFLAGS_MOS) $(INCLUDES_MOS) -o $@ src/iGameMain.c
-
-src/strfuncs_MOS.o: src/strfuncs.c src/strfuncs.h
-	$(CC) $(CFLAGS_MOS) $(INCLUDES_MOS) -o $@ src/strfuncs.c
-
-src/iGame_cat_MOS.o: src/iGame_cat.c
-	$(CC) $(CFLAGS_MOS) $(INCLUDES_MOS) -o $@ src/iGame_cat.c
+include make_includes/obj_mos.inc
 
 ##########################################################################
 # object files (AOS4)
 ##########################################################################
 
-src/funcs_OS4.o: src/funcs.c src/iGame_cat.h src/strfuncs.h
-	$(CC) $(CFLAGS_OS4) $(INCLUDES_OS4) -o $@ src/funcs.c
-
-src/iGameGUI_OS4.o: src/iGameGUI.c src/iGameGUI.h src/iGame_cat.h
-	$(CC) $(CFLAGS_OS4) $(INCLUDES_OS4) -o $@ src/iGameGUI.c
-
-src/iGameMain_OS4.o: src/iGameMain.c
-	$(CC) $(CFLAGS_OS4) $(INCLUDES_OS4) -o $@ src/iGameMain.c
-
-src/strfuncs_OS4.o: src/strfuncs.c src/strfuncs.h
-	$(CC) $(CFLAGS_OS4) $(INCLUDES_OS4) -o $@ src/strfuncs.c
-
-src/iGame_cat_OS4.o: src/iGame_cat.c
-	$(CC) $(CFLAGS_OS4) $(INCLUDES_OS4) -o $@ src/iGame_cat.c
+include make_includes/obj_os4.inc
 
 ##########################################################################
 # generic build options

--- a/make_includes/obj_000.inc
+++ b/make_includes/obj_000.inc
@@ -1,0 +1,18 @@
+##########################################################################
+# object files (generic 000)
+##########################################################################
+
+src/funcs.o: src/funcs.c src/iGame_cat.h src/strfuncs.h
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ src/funcs.c
+
+src/iGameGUI.o: src/iGameGUI.c src/iGameGUI.h src/version.h src/iGame_cat.h
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ src/iGameGUI.c
+
+src/iGameMain.o: src/iGameMain.c
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ src/iGameMain.c
+
+src/strfuncs.o: src/strfuncs.c src/strfuncs.h
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ src/strfuncs.c
+
+src/iGame_cat.o: src/iGame_cat.c
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ src/iGame_cat.c

--- a/make_includes/obj_030.inc
+++ b/make_includes/obj_030.inc
@@ -1,0 +1,18 @@
+##########################################################################
+# object files (030)
+##########################################################################
+
+src/funcs_030.o: src/funcs.c src/iGame_cat.h src/strfuncs.h
+	$(CC) $(CFLAGS_030) $(INCLUDES) -o $@ src/funcs.c
+
+src/iGameGUI_030.o: src/iGameGUI.c src/iGameGUI.h src/iGame_cat.h
+	$(CC) $(CFLAGS_030) $(INCLUDES) -o $@ src/iGameGUI.c
+
+src/iGameMain_030.o: src/iGameMain.c
+	$(CC) $(CFLAGS_030) $(INCLUDES) -o $@ src/iGameMain.c
+
+src/strfuncs_030.o: src/strfuncs.c src/strfuncs.h
+	$(CC) $(CFLAGS_030) $(INCLUDES) -o $@ src/strfuncs.c
+
+src/iGame_cat_030.o: src/iGame_cat.c
+	$(CC) $(CFLAGS_030) $(INCLUDES) -o $@ src/iGame_cat.c

--- a/make_includes/obj_040.inc
+++ b/make_includes/obj_040.inc
@@ -1,0 +1,18 @@
+##########################################################################
+# object files (040)
+##########################################################################
+
+src/funcs_040.o: src/funcs.c src/iGame_cat.h src/strfuncs.h
+	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/funcs.c
+
+src/iGameGUI_040.o: src/iGameGUI.c src/iGameGUI.h src/iGame_cat.h
+	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/iGameGUI.c
+
+src/iGameMain_040.o: src/iGameMain.c
+	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/iGameMain.c
+
+src/strfuncs_040.o: src/strfuncs.c src/strfuncs.h
+	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/strfuncs.c
+
+src/iGame_cat_040.o: src/iGame_cat.c
+	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/iGame_cat.c

--- a/make_includes/obj_060.inc
+++ b/make_includes/obj_060.inc
@@ -1,0 +1,18 @@
+##########################################################################
+# object files (060)
+##########################################################################
+
+src/funcs_060.o: src/funcs.c src/iGame_cat.h src/strfuncs.h
+	$(CC) $(CFLAGS_060) $(INCLUDES) -o $@ src/funcs.c
+
+src/iGameGUI_060.o: src/iGameGUI.c src/iGameGUI.h src/iGame_cat.h
+	$(CC) $(CFLAGS_060) $(INCLUDES) -o $@ src/iGameGUI.c
+
+src/iGameMain_060.o: src/iGameMain.c
+	$(CC) $(CFLAGS_060) $(INCLUDES) -o $@ src/iGameMain.c
+
+src/strfuncs_060.o: src/strfuncs.c
+	$(CC) $(CFLAGS_060) $(INCLUDES) -o $@ src/strfuncs.c
+
+src/iGame_cat_060.o: src/iGame_cat.c
+	$(CC) $(CFLAGS_060) $(INCLUDES) -o $@ src/iGame_cat.c

--- a/make_includes/obj_files.inc
+++ b/make_includes/obj_files.inc
@@ -1,0 +1,10 @@
+##########################################################################
+# Object files which are part of iGame
+##########################################################################
+
+OBJS		= src/funcs.o src/iGameGUI.o src/iGameMain.o src/strfuncs.o src/iGame_cat.o
+OBJS_030	= src/funcs_030.o src/iGameGUI_030.o src/iGameMain_030.o src/strfuncs_030.o src/iGame_cat_030.o
+OBJS_040	= src/funcs_040.o src/iGameGUI_040.o src/iGameMain_040.o src/strfuncs_040.o src/iGame_cat_040.o
+OBJS_060	= src/funcs_060.o src/iGameGUI_060.o src/iGameMain_060.o src/strfuncs_060.o src/iGame_cat_060.o
+OBJS_MOS	= src/funcs_MOS.o src/iGameGUI_MOS.o src/iGameMain_MOS.o src/strfuncs_MOS.o src/iGame_cat_MOS.o
+OBJS_OS4	= src/funcs_OS4.o src/iGameGUI_OS4.o src/iGameMain_OS4.o src/strfuncs_OS4.o src/iGame_cat_OS4.o

--- a/make_includes/obj_mos.inc
+++ b/make_includes/obj_mos.inc
@@ -1,0 +1,18 @@
+##########################################################################
+# object files (MOS)
+##########################################################################
+
+src/funcs_MOS.o: src/funcs.c src/iGame_cat.h src/strfuncs.h
+	$(CC) $(CFLAGS_MOS) $(INCLUDES_MOS) -o $@ src/funcs.c
+
+src/iGameGUI_MOS.o: src/iGameGUI.c src/iGameGUI.h src/iGame_cat.h
+	$(CC) $(CFLAGS_MOS) $(INCLUDES_MOS) -o $@ src/iGameGUI.c
+
+src/iGameMain_MOS.o: src/iGameMain.c
+	$(CC) $(CFLAGS_MOS) $(INCLUDES_MOS) -o $@ src/iGameMain.c
+
+src/strfuncs_MOS.o: src/strfuncs.c src/strfuncs.h
+	$(CC_PPC) $(CFLAGS_MOS) $(INCLUDES_MOS) -o $@ src/strfuncs.c
+
+src/iGame_cat_MOS.o: src/iGame_cat.c
+	$(CC_PPC) $(CFLAGS_MOS) $(INCLUDES_MOS) -o $@ src/iGame_cat.c

--- a/make_includes/obj_os4.inc
+++ b/make_includes/obj_os4.inc
@@ -1,0 +1,18 @@
+##########################################################################
+# object files (AOS4)
+##########################################################################
+
+src/funcs_OS4.o: src/funcs.c src/iGame_cat.h src/strfuncs.h
+	$(CC) $(CFLAGS_OS4) $(INCLUDES_OS4) -o $@ src/funcs.c
+
+src/iGameGUI_OS4.o: src/iGameGUI.c src/iGameGUI.h src/iGame_cat.h
+	$(CC) $(CFLAGS_OS4) $(INCLUDES_OS4) -o $@ src/iGameGUI.c
+
+src/iGameMain_OS4.o: src/iGameMain.c
+	$(CC) $(CFLAGS_OS4) $(INCLUDES_OS4) -o $@ src/iGameMain.c
+
+src/strfuncs_OS4.o: src/strfuncs.c src/strfuncs.h
+	$(CC_PPC) $(CFLAGS_OS4) $(INCLUDES_OS4) -o $@ src/strfuncs.c
+
+src/iGame_cat_OS4.o: src/iGame_cat.c
+	$(CC_PPC) $(CFLAGS_OS4) $(INCLUDES_OS4) -o $@ src/iGame_cat.c

--- a/make_includes/rules.inc
+++ b/make_includes/rules.inc
@@ -1,0 +1,21 @@
+##########################################################################
+# Rule for building
+##########################################################################
+
+iGame: $(OBJS)
+	$(LINK) $(OBJS) $(LIBFLAGS) $@
+
+iGame.030: $(OBJS_030)
+	$(LINK) $(OBJS_030) $(LIBFLAGS) $@
+
+iGame.040: $(OBJS_040)
+	$(LINK) $(OBJS_040) $(LIBFLAGS) $@
+
+iGame.060: $(OBJS_060)
+	$(LINK) $(OBJS_060) $(LIBFLAGS) $@
+
+iGame.MOS: $(OBJS_MOS)
+	$(LINK_PPC) $(OBJS_MOS) $(LIBFLAGS_MOS) $@
+
+iGame.OS4: $(OBJS_OS4)
+	$(LINK_PPC) $(OBJS_OS4) $(LIBFLAGS_OS4) $@


### PR DESCRIPTION
We have a lot of Makefiles for different system, but a lot of their parts are common. I broke them to separated files, so that when we need to make a change, this is going to be applied to all setups.