### PR TITLE
Filesystem functions moved to new file

### DIFF
--- a/make_includes/obj_000.inc
+++ b/make_includes/obj_000.inc
@@ -2,10 +2,10 @@
 # object files (generic 000)
 ##########################################################################
 
-src/funcs.o: src/funcs.c src/iGame_cat.h src/strfuncs.h
+src/funcs.o: src/funcs.c src/iGame_cat.h src/strfuncs.h src/fsfuncs.h
 	$(CC) $(CFLAGS) $(INCLUDES) -o $@ src/funcs.c
 
-src/iGameGUI.o: src/iGameGUI.c src/iGameGUI.h src/version.h src/iGame_cat.h
+src/iGameGUI.o: src/iGameGUI.c src/iGameGUI.h src/iGame_cat.h src/fsfuncs.h
 	$(CC) $(CFLAGS) $(INCLUDES) -o $@ src/iGameGUI.c
 
 src/iGameMain.o: src/iGameMain.c
@@ -13,6 +13,9 @@ src/iGameMain.o: src/iGameMain.c
 
 src/strfuncs.o: src/strfuncs.c src/strfuncs.h
 	$(CC) $(CFLAGS) $(INCLUDES) -o $@ src/strfuncs.c
+
+src/fsfuncs.o: src/fsfuncs.c src/fsfuncs.h
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ src/fsfuncs.c
 
 src/iGame_cat.o: src/iGame_cat.c
 	$(CC) $(CFLAGS) $(INCLUDES) -o $@ src/iGame_cat.c

--- a/make_includes/obj_030.inc
+++ b/make_includes/obj_030.inc
@@ -2,10 +2,10 @@
 # object files (030)
 ##########################################################################
 
-src/funcs_030.o: src/funcs.c src/iGame_cat.h src/strfuncs.h
+src/funcs_030.o: src/funcs.c src/iGame_cat.h src/strfuncs.h src/fsfuncs.h
 	$(CC) $(CFLAGS_030) $(INCLUDES) -o $@ src/funcs.c
 
-src/iGameGUI_030.o: src/iGameGUI.c src/iGameGUI.h src/iGame_cat.h
+src/iGameGUI_030.o: src/iGameGUI.c src/iGameGUI.h src/iGame_cat.h src/fsfuncs.h
 	$(CC) $(CFLAGS_030) $(INCLUDES) -o $@ src/iGameGUI.c
 
 src/iGameMain_030.o: src/iGameMain.c
@@ -13,6 +13,9 @@ src/iGameMain_030.o: src/iGameMain.c
 
 src/strfuncs_030.o: src/strfuncs.c src/strfuncs.h
 	$(CC) $(CFLAGS_030) $(INCLUDES) -o $@ src/strfuncs.c
+
+src/fsfuncs_030.o: src/fsfuncs.c src/fsfuncs.h src/funcs.h src/iGameExtern.h
+	$(CC) $(CFLAGS_030) $(INCLUDES) -o $@ src/fsfuncs.c
 
 src/iGame_cat_030.o: src/iGame_cat.c
 	$(CC) $(CFLAGS_030) $(INCLUDES) -o $@ src/iGame_cat.c

--- a/make_includes/obj_040.inc
+++ b/make_includes/obj_040.inc
@@ -2,10 +2,10 @@
 # object files (040)
 ##########################################################################
 
-src/funcs_040.o: src/funcs.c src/iGame_cat.h src/strfuncs.h
+src/funcs_040.o: src/funcs.c src/iGame_cat.h src/strfuncs.h src/fsfuncs.h
 	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/funcs.c
 
-src/iGameGUI_040.o: src/iGameGUI.c src/iGameGUI.h src/iGame_cat.h
+src/iGameGUI_040.o: src/iGameGUI.c src/iGameGUI.h src/iGame_cat.h src/fsfuncs.h
 	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/iGameGUI.c
 
 src/iGameMain_040.o: src/iGameMain.c
@@ -13,6 +13,9 @@ src/iGameMain_040.o: src/iGameMain.c
 
 src/strfuncs_040.o: src/strfuncs.c src/strfuncs.h
 	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/strfuncs.c
+
+src/fsfuncs_040.o: src/fsfuncs.c src/fsfuncs.h
+	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/fsfuncs.c
 
 src/iGame_cat_040.o: src/iGame_cat.c
 	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/iGame_cat.c

--- a/make_includes/obj_060.inc
+++ b/make_includes/obj_060.inc
@@ -2,10 +2,10 @@
 # object files (060)
 ##########################################################################
 
-src/funcs_060.o: src/funcs.c src/iGame_cat.h src/strfuncs.h
+src/funcs_060.o: src/funcs.c src/iGame_cat.h src/strfuncs.h src/fsfuncs.h
 	$(CC) $(CFLAGS_060) $(INCLUDES) -o $@ src/funcs.c
 
-src/iGameGUI_060.o: src/iGameGUI.c src/iGameGUI.h src/iGame_cat.h
+src/iGameGUI_060.o: src/iGameGUI.c src/iGameGUI.h src/iGame_cat.h src/fsfuncs.h
 	$(CC) $(CFLAGS_060) $(INCLUDES) -o $@ src/iGameGUI.c
 
 src/iGameMain_060.o: src/iGameMain.c
@@ -13,6 +13,9 @@ src/iGameMain_060.o: src/iGameMain.c
 
 src/strfuncs_060.o: src/strfuncs.c
 	$(CC) $(CFLAGS_060) $(INCLUDES) -o $@ src/strfuncs.c
+
+src/fsfuncs_060.o: src/fsfuncs.c src/fsfuncs.h
+	$(CC) $(CFLAGS_060) $(INCLUDES) -o $@ src/fsfuncs.c
 
 src/iGame_cat_060.o: src/iGame_cat.c
 	$(CC) $(CFLAGS_060) $(INCLUDES) -o $@ src/iGame_cat.c

--- a/make_includes/obj_files.inc
+++ b/make_includes/obj_files.inc
@@ -2,9 +2,9 @@
 # Object files which are part of iGame
 ##########################################################################
 
-OBJS		= src/funcs.o src/iGameGUI.o src/iGameMain.o src/strfuncs.o src/iGame_cat.o
-OBJS_030	= src/funcs_030.o src/iGameGUI_030.o src/iGameMain_030.o src/strfuncs_030.o src/iGame_cat_030.o
-OBJS_040	= src/funcs_040.o src/iGameGUI_040.o src/iGameMain_040.o src/strfuncs_040.o src/iGame_cat_040.o
-OBJS_060	= src/funcs_060.o src/iGameGUI_060.o src/iGameMain_060.o src/strfuncs_060.o src/iGame_cat_060.o
-OBJS_MOS	= src/funcs_MOS.o src/iGameGUI_MOS.o src/iGameMain_MOS.o src/strfuncs_MOS.o src/iGame_cat_MOS.o
-OBJS_OS4	= src/funcs_OS4.o src/iGameGUI_OS4.o src/iGameMain_OS4.o src/strfuncs_OS4.o src/iGame_cat_OS4.o
+OBJS		= src/funcs.o src/iGameGUI.o src/iGameMain.o src/strfuncs.o src/fsfuncs.o src/iGame_cat.o
+OBJS_030	= src/funcs_030.o src/iGameGUI_030.o src/iGameMain_030.o src/strfuncs_030.o src/fsfuncs_030.o src/iGame_cat_030.o
+OBJS_040	= src/funcs_040.o src/iGameGUI_040.o src/iGameMain_040.o src/strfuncs_040.o src/fsfuncs_040.o src/iGame_cat_040.o
+OBJS_060	= src/funcs_060.o src/iGameGUI_060.o src/iGameMain_060.o src/strfuncs_060.o src/fsfuncs_060.o src/iGame_cat_060.o
+OBJS_MOS	= src/funcs_MOS.o src/iGameGUI_MOS.o src/iGameMain_MOS.o src/strfuncs_MOS.o src/fsfuncs_MOS.o src/iGame_cat_MOS.o
+OBJS_OS4	= src/funcs_OS4.o src/iGameGUI_OS4.o src/iGameMain_OS4.o src/strfuncs_OS4.o src/fsfuncs_OS4.o src/iGame_cat_OS4.o

--- a/make_includes/obj_mos.inc
+++ b/make_includes/obj_mos.inc
@@ -2,10 +2,10 @@
 # object files (MOS)
 ##########################################################################
 
-src/funcs_MOS.o: src/funcs.c src/iGame_cat.h src/strfuncs.h
+src/funcs_MOS.o: src/funcs.c src/iGame_cat.h src/strfuncs.h src/fsfuncs.h
 	$(CC) $(CFLAGS_MOS) $(INCLUDES_MOS) -o $@ src/funcs.c
 
-src/iGameGUI_MOS.o: src/iGameGUI.c src/iGameGUI.h src/iGame_cat.h
+src/iGameGUI_MOS.o: src/iGameGUI.c src/iGameGUI.h src/iGame_cat.h src/fsfuncs.h
 	$(CC) $(CFLAGS_MOS) $(INCLUDES_MOS) -o $@ src/iGameGUI.c
 
 src/iGameMain_MOS.o: src/iGameMain.c
@@ -13,6 +13,9 @@ src/iGameMain_MOS.o: src/iGameMain.c
 
 src/strfuncs_MOS.o: src/strfuncs.c src/strfuncs.h
 	$(CC_PPC) $(CFLAGS_MOS) $(INCLUDES_MOS) -o $@ src/strfuncs.c
+
+src/fsfuncs_MOS.o: src/fsfuncs.c src/fsfuncs.h
+	$(CC_PPC) $(CFLAGS_MOS) $(INCLUDES_MOS) -o $@ src/fsfuncs.c
 
 src/iGame_cat_MOS.o: src/iGame_cat.c
 	$(CC_PPC) $(CFLAGS_MOS) $(INCLUDES_MOS) -o $@ src/iGame_cat.c

--- a/make_includes/obj_os4.inc
+++ b/make_includes/obj_os4.inc
@@ -2,10 +2,10 @@
 # object files (AOS4)
 ##########################################################################
 
-src/funcs_OS4.o: src/funcs.c src/iGame_cat.h src/strfuncs.h
+src/funcs_OS4.o: src/funcs.c src/iGame_cat.h src/strfuncs.h src/fsfuncs.h
 	$(CC) $(CFLAGS_OS4) $(INCLUDES_OS4) -o $@ src/funcs.c
 
-src/iGameGUI_OS4.o: src/iGameGUI.c src/iGameGUI.h src/iGame_cat.h
+src/iGameGUI_OS4.o: src/iGameGUI.c src/iGameGUI.h src/iGame_cat.h src/fsfuncs.h
 	$(CC) $(CFLAGS_OS4) $(INCLUDES_OS4) -o $@ src/iGameGUI.c
 
 src/iGameMain_OS4.o: src/iGameMain.c
@@ -13,6 +13,9 @@ src/iGameMain_OS4.o: src/iGameMain.c
 
 src/strfuncs_OS4.o: src/strfuncs.c src/strfuncs.h
 	$(CC_PPC) $(CFLAGS_OS4) $(INCLUDES_OS4) -o $@ src/strfuncs.c
+
+src/fsfuncs_OS4.o: src/fsfuncs.c src/fsfuncs.h
+	$(CC_PPC) $(CFLAGS_OS4) $(INCLUDES_OS4) -o $@ src/fsfuncs.c
 
 src/iGame_cat_OS4.o: src/iGame_cat.c
 	$(CC_PPC) $(CFLAGS_OS4) $(INCLUDES_OS4) -o $@ src/iGame_cat.c

--- a/src/fsfuncs.c
+++ b/src/fsfuncs.c
@@ -1,0 +1,486 @@
+/*
+  iGameMain.c
+  Filesystem functions source for iGame
+
+  Copyright (c) 2018, Emmanuel Vasilakis
+
+  This file is part of iGame.
+
+  iGame is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  iGame is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with iGame. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+/* MUI */
+#include <libraries/mui.h>
+
+/* Prototypes */
+#include <clib/alib_protos.h>
+#include <proto/wb.h>
+
+#if defined(__amigaos4__)
+#include <proto/exec.h>
+#include <proto/dos.h>
+#include <proto/icon.h>
+#include <proto/muimaster.h>
+#else
+#include <clib/exec_protos.h>
+#include <clib/dos_protos.h>
+#include <clib/icon_protos.h>
+#include <clib/muimaster_protos.h>
+#endif
+
+/* System */
+#if defined(__amigaos4__)
+// #include <dos/obsolete.h>
+#define ASL_PRE_V38_NAMES
+#endif
+#include <libraries/asl.h>
+
+/* ANSI C */
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "iGameGUI.h"
+#include "iGameExtern.h"
+#include "iGame_cat.h"
+#include "strfuncs.h"
+#include "funcs.h"
+#include "fsfuncs.h"
+
+extern struct ObjApp* app;
+extern char* executable_name;
+
+/* structures */
+struct FileRequester* request;
+
+/* global variables */
+extern char fname[255];
+extern games_list *item_games, *games;
+extern igame_settings *current_settings;
+
+
+void strip_path(const char *path, char *naked_path)
+{
+	int i, k;
+	/* strip the path from the slave file and get the rest */
+	for (i = strlen(path) - 1; i >= 0; i--)
+	{
+		if (path[i] == '/')
+			break;
+	}
+
+	for (k = 0; k <= i - 1; k++)
+		naked_path[k] = path[k];
+	naked_path[k] = '\0';
+}
+
+char* get_slave_from_path(char *slave, int start, char *path)
+{
+	int z = 0;
+	for (int k = start + 1; k <= strlen(path); k++)
+	{
+		slave[z] = path[k];
+		z++;
+	}
+	return slave;
+}
+
+/*
+ * Check if a path actually exists in hard disk.
+ * - Return True if exists
+ * - Return False if it doesn't exist
+ */
+int check_path_exists(char *path)
+{
+	const BPTR lock = Lock(path, ACCESS_READ);
+	if (!lock) {
+		return FALSE;
+	}
+
+	UnLock(lock);
+	return TRUE;
+}
+
+BOOL get_filename(const char *title, const char *positive_text, const BOOL save_mode)
+{
+	BOOL result = FALSE;
+	if ((request = MUI_AllocAslRequest(ASL_FileRequest, NULL)) != NULL)
+	{
+		if (MUI_AslRequestTags(request,
+		                       ASLFR_TitleText, title,
+		                       ASLFR_PositiveText, positive_text,
+		                       ASLFR_DoSaveMode, save_mode,
+		                       ASLFR_InitialDrawer, PROGDIR,
+		                       TAG_DONE))
+		{
+			memset(&fname[0], 0, sizeof fname);
+			strcat(fname, request->fr_Drawer);
+			if (fname[strlen(fname) - 1] != (UBYTE)58) /* Check for : */
+				strcat(fname, "/");
+			strcat(fname, request->fr_File);
+
+			result = TRUE;
+		}
+
+		if (request)
+			MUI_FreeAslRequest(request);
+	}
+
+	return result;
+}
+
+void save_to_csv(const char *filename, const int check_exists)
+{
+	char csvFilename[32];
+	FILE *fpgames;
+
+	const char* saving_message = (const char*)GetMBString(MSG_SavingGamelist);
+	set(app->TX_Status, MUIA_Text_Contents, saving_message);
+
+	strcpy(csvFilename, (CONST_STRPTR)filename);
+	strcat(csvFilename, ".csv");
+
+	fpgames = fopen(csvFilename,"w");
+	if (!fpgames)
+	{
+		msg_box((const char*)GetMBString(MSG_FailedOpeningGameslist));
+		return;
+	}
+
+	for (item_games = games; item_games != NULL; item_games = item_games->next)
+	{
+		if (check_exists == 1)
+		{
+			if (item_games->exists == 1)
+			{
+				if (strlen(item_games->genre) == 0)
+					strcpy(item_games->genre, "Unknown");
+				fprintf(
+					fpgames,
+					"%d;%s;%s;%s;%d;%d;%d;%d\n",
+					item_games->index, item_games->title, item_games->genre, item_games->path,
+					item_games->favorite, item_games->times_played, item_games->last_played, item_games->hidden
+				);
+			}
+			else
+			{
+				strcpy(item_games->path, "");
+			}
+		}
+		else
+		{
+			if (strlen(item_games->genre) == 0)
+				strcpy(item_games->genre, "Unknown");
+			fprintf(
+				fpgames,
+				"%d;%s;%s;%s;%d;%d;%d;%d\n",
+				item_games->index, item_games->title, item_games->genre, item_games->path,
+				item_games->favorite, item_games->times_played, item_games->last_played, item_games->hidden
+			);
+		}
+	}
+	fclose(fpgames);
+
+	status_show_total();
+}
+
+void read_tool_types(void)
+{
+	struct Library *icon_base;
+	struct DiskObject *disk_obj;
+
+	int screen_width, screen_height;
+	unsigned char filename[32];
+
+	if ((icon_base = (struct Library *)OpenLibrary((CONST_STRPTR)ICON_LIBRARY, 0)))
+	{
+		strcpy(filename, PROGDIR);
+		strcat(filename, executable_name);
+
+		if ((disk_obj = GetDiskObject((STRPTR)filename)))
+		{
+			if (FindToolType(disk_obj->do_ToolTypes, (STRPTR)TOOLTYPE_SCREENSHOT))
+			{
+				char** tool_types = (char **)disk_obj->do_ToolTypes;
+				char* tool_type = *tool_types;
+
+				char** temp_tbl = my_split((char *)tool_type, "=");
+				if (temp_tbl == NULL
+					|| temp_tbl[0] == NULL
+					|| !strcmp(temp_tbl[0], " ")
+					|| !strcmp(temp_tbl[0], ""))
+				{
+					msg_box((const char*)GetMBString(MSG_BadTooltype));
+					exit(0);
+				}
+
+				if (temp_tbl[1] != NULL)
+				{
+					char** temp_tbl2 = my_split((char *)temp_tbl[1], "x");
+					if (temp_tbl2[0]) current_settings->screenshot_width = atoi((char *)temp_tbl2[0]);
+					if (temp_tbl2[1]) current_settings->screenshot_height = atoi((char *)temp_tbl2[1]);
+
+					free(temp_tbl2[0]);
+					free(temp_tbl2[1]);
+					free(temp_tbl2);
+					free(temp_tbl[0]);
+					free(temp_tbl[1]);
+					free(temp_tbl);
+				}
+			}
+
+			if (FindToolType(disk_obj->do_ToolTypes, (STRPTR)TOOLTYPE_NOGUIGFX))
+				current_settings->no_guigfx = 1;
+
+			if (FindToolType(disk_obj->do_ToolTypes, (STRPTR)TOOLTYPE_FILTERUSEENTER))
+				current_settings->filter_use_enter = 1;
+
+			if (FindToolType(disk_obj->do_ToolTypes, (STRPTR)TOOLTYPE_NOSCREENSHOT))
+				current_settings->hide_screenshots = 1;
+
+			if (FindToolType(disk_obj->do_ToolTypes, (STRPTR)TOOLTYPE_SAVESTATSONEXIT))
+				current_settings->save_stats_on_exit = 1;
+
+			if (FindToolType(disk_obj->do_ToolTypes, (STRPTR)TOOLTYPE_TITLESFROMDIRS))
+				current_settings->titles_from_dirs = 1;
+
+			if (FindToolType(disk_obj->do_ToolTypes, (STRPTR)TOOLTYPE_NOSMARTSPACES))
+				current_settings->no_smart_spaces = 1;
+
+			if (FindToolType(disk_obj->do_ToolTypes, (STRPTR)TOOLTYPE_NOSIDEPANEL))
+				current_settings->hide_side_panel = 1;
+		}
+		CloseLibrary(icon_base);
+	}
+
+	if (!current_settings->hide_side_panel)
+	{
+		//check screen res and adjust image box accordingly
+		if (current_settings->screenshot_height <= 0 && current_settings->screenshot_width <= 0)
+		{
+			get_screen_size(&screen_width, &screen_height);
+
+			//if values are ok from the previous function, and user has not provided his own values, calculate a nice size
+			if (screen_width != -1 && screen_height != -1)
+			{
+				//for hi-res screens (1024x768 or greater) we'll use 320x256
+				if (screen_width >= 1024 && screen_height >= 768)
+				{
+					current_settings->screenshot_width = 320;
+					current_settings->screenshot_height = 256;
+				}
+				else
+				{
+					// for anything less, we'll go with half that
+					current_settings->screenshot_width = 160;
+					current_settings->screenshot_height = 128;
+				}
+			}
+			else
+			{
+				current_settings->screenshot_width = 160;
+				current_settings->screenshot_height = 128;
+			}
+		}
+	}
+}
+
+/*
+* Gets title from a slave file
+* returns 0 on success, 1 on fail
+*/
+int get_title_from_slave(char* slave, char* title)
+{
+	char slave_title[100];
+
+	struct slave_info
+	{
+		unsigned long security;
+		char id[8];
+		unsigned short version;
+		unsigned short flags;
+		unsigned long base_mem_size;
+		unsigned long exec_install;
+		unsigned short game_loader;
+		unsigned short current_dir;
+		unsigned short dont_cache;
+		char keydebug;
+		char keyexit;
+		unsigned long exp_mem;
+		unsigned short name;
+		unsigned short copy;
+		unsigned short info;
+	};
+
+	struct slave_info sl;
+
+	FILE* fp = fopen(slave, "rbe");
+	if (fp == NULL)
+	{
+		return 1;
+	}
+
+	//seek to +0x20
+	fseek(fp, 32, SEEK_SET);
+	fread(&sl, 1, sizeof sl, fp);
+
+	//sl.Version = (sl.Version>>8) | (sl.Version<<8);
+	//sl.name = (sl.name>>8) | (sl.name<<8);
+
+	//printf ("[%s] [%d]\n", sl.ID, sl.Version);
+
+	//sl.name holds the offset for the slave name
+	fseek(fp, sl.name + 32, SEEK_SET);
+	//title = calloc (1, 100);
+	//fread (title, 1, 100, fp);
+
+	if (sl.version < 10)
+	{
+		return 1;
+	}
+
+	for (int i = 0; i <= 99; i++)
+	{
+		slave_title[i] = fgetc(fp);
+		if (slave_title[i] == '\n')
+		{
+			slave_title[i] = '\0';
+			break;
+		}
+	}
+
+	strcpy(title, slave_title);
+	fclose(fp);
+
+	return 0;
+}
+
+// Get the Directory part from a full path containing a file
+const char* get_directory_name(const char* str)
+{
+	int pos1 = get_delimiter_position(str);
+	if (!pos1)
+		return NULL;
+
+	char full_path[100];
+	strncpy(full_path, str, pos1);
+	full_path[pos1] = '\0';
+
+	const int pos2 = get_delimiter_position(full_path);
+	if (!pos2)
+		return NULL;
+
+	char* dir_name = malloc(sizeof full_path);
+	int c = 0;
+	for (unsigned int i = pos2 + 1; i <= sizeof full_path; i++)
+	{
+		dir_name[c] = full_path[i];
+		c++;
+	}
+	dir_name[c] = '\0';
+
+	return dir_name;
+}
+
+// Get the complete directory path from a full path containing a file
+const char *get_directory_path(const char *str)
+{
+	int pos1 = get_delimiter_position(str);
+	if (!pos1)
+		return NULL;
+
+	char *dir_name = malloc(pos1 + 1);
+	strncpy(dir_name, str, pos1);
+	dir_name[pos1] = '\0';
+
+	return dir_name;
+}
+
+// Get the application's executable name
+const char *get_executable_name(int argc, char **argv)
+{
+	// argc is zero when run from the Workbench,
+	// positive when run from the CLI
+	if (argc == 0)
+	{
+		// in AmigaOS, argv is a pointer to the WBStartup message
+		// when argc is zero (run under the Workbench)
+		struct WBStartup* argmsg = (struct WBStartup *)argv;
+		struct WBArg* wb_arg = argmsg->sm_ArgList; /* head of the arg list */
+
+		executable_name = wb_arg->wa_Name;
+	}
+	else
+	{
+		// Run from the CLI
+		executable_name = argv[0];
+	}
+
+	return executable_name;
+}
+
+void open_current_dir(void)
+{
+	// Allocate Memory for variables
+	char *game_title = NULL;
+	const char *path_only = NULL;
+
+	if (get_wb_version() < 44)
+	{
+		// workbench.library doesn't support OpenWorkbenchObjectA yet
+		return;
+	}
+
+	//set the elements on the window
+	DoMethod(app->LV_GamesList, MUIM_List_GetEntry, MUIV_List_GetEntry_Active, &game_title);
+	if (game_title == NULL || strlen(game_title) == 0)
+	{
+		msg_box((const char*)GetMBString(MSG_SelectGameFromList));
+		return;
+	}
+
+	const int found = title_exists(game_title);
+	if (!found)
+	{
+		msg_box((const char*)GetMBString(MSG_SelectGameFromList));
+		return;
+	}
+
+	path_only = get_directory_path(item_games->path);
+	if(!path_only)
+	{
+		msg_box((const char*)GetMBString(MSG_DirectoryNotFound));
+		return;
+	}
+
+	//Open path directory
+	OpenWorkbenchObject((char *)path_only);
+	free(path_only); // get_directory_path uses malloc()
+}
+
+void get_path(char *title, char *path)
+{
+	for (item_games = games; item_games != NULL; item_games = item_games->next)
+	{
+		if (item_games->deleted != 1)
+		{
+			if (!strcmp(title, item_games->title))
+			{
+				strcpy(path, item_games->path);
+				break;
+			}
+		}
+	}
+}

--- a/src/fsfuncs.h
+++ b/src/fsfuncs.h
@@ -1,6 +1,6 @@
 /*
   iGameMain.c
-  String functions header for iGame
+  Filesystem functions header for iGame
 
   Copyright (c) 2018, Emmanuel Vasilakis
 
@@ -20,14 +20,20 @@
   along with iGame. If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef _STR_FUNCS_H
-#define _STR_FUNCS_H
+#ifndef _FS_FUNCS_H
+#define _FS_FUNCS_H
 
-char *strcasestr(const char *, const char *);
-char* strdup(const char *); // TODO: Possible obsolete. Maybe needed on some old tools. Better move it there
-void string_to_lower(char *);
-char** my_split(char *, char *);
-int get_delimiter_position(const char *);
-const char* add_spaces_to_string(const char *);
+void strip_path(const char *, char *);
+char *get_slave_from_path(char *, int, char *);
+int check_path_exists(char *);
+BOOL get_filename(const char *, const char *, const BOOL);
+void save_to_csv(const char *, const int);
+void read_tool_types(void);
+int get_title_from_slave(char *, char *);
+const char *get_directory_name(const char *);
+const char *get_directory_path(const char *);
+const char *get_executable_name(int, char **);
+void open_current_dir(void);
+void get_path(char *, char *);
 
 #endif

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -26,7 +26,6 @@
 #include <mui/TextEditor_mcc.h>
 
 /* Prototypes */
-#include <clib/alib_protos.h>
 #include <proto/wb.h>
 
 #if defined(__amigaos4__)
@@ -44,18 +43,10 @@
 #endif
 
 /* System */
-#include <dos/dos.h>
 #if defined(__amigaos4__)
 #include <dos/obsolete.h>
-#endif
-#include <exec/memory.h>
-#include <exec/types.h>
-#if defined(__amigaos4__)
 #define ASL_PRE_V38_NAMES
 #endif
-#include <libraries/asl.h>
-#include <workbench/startup.h>
-#include <workbench/workbench.h>
 
 /* ANSI C */
 #include <stdio.h>
@@ -67,6 +58,8 @@
 #include "iGameExtern.h"
 #include "iGame_cat.h"
 #include "strfuncs.h"
+#include "fsfuncs.h"
+#include "funcs.h"
 
 extern struct ObjApp* app;
 extern char* executable_name;
@@ -83,31 +76,20 @@ int wbrun = 0;
 
 /* function definitions */
 int get_genre(char* title, char* genre);
-void get_path(char* title, char* path);
 void follow_thread(BPTR lock, int tab_level);
 void refresh_list(int check_exists);
 int hex2dec(char* hexin);
-void msg_box(const char* msg);
-int get_title_from_slave(char* slave, char* title);
 int check_dup_title(char* title);
-const char* get_directory_name(const char* str);
-const char* get_directory_path(const char* str);
-const char* get_executable_name(int argc, char** argv);
-void strip_path(const char* path, char* naked_path);
-char* get_slave_from_path(char* slave, int start, char* path);
-void read_tool_types();
 void check_for_wbrun();
 void list_show_favorites(char* str);
-int check_path_exists(char* path);
 
 /* structures */
 struct EasyStruct msgbox;
-struct FileRequester* request;
 
 games_list *item_games = NULL, *games = NULL;
 repos_list *item_repos = NULL, *repos = NULL;
 genres_list *item_genres = NULL, *genres = NULL;
-igame_settings* current_settings = NULL;
+igame_settings *current_settings = NULL;
 
 const unsigned char* GetMBString(const unsigned char* ref)
 {
@@ -116,7 +98,7 @@ const unsigned char* GetMBString(const unsigned char* ref)
 	return ref;
 }
 
-void status_show_total()
+void status_show_total(void)
 {
 	char helper[200];
 	set(app->LV_GamesList, MUIA_List_Quiet, FALSE);
@@ -1128,21 +1110,6 @@ void refresh_sidepanel()
 	DoMethod(app->GR_sidepanel, MUIM_Group_ExitChange);
 }
 
-void strip_path(const char* path, char* naked_path)
-{
-	int i, k;
-	/* strip the path from the slave file and get the rest */
-	for (i = strlen(path) - 1; i >= 0; i--)
-	{
-		if (path[i] == '/')
-			break;
-	}
-
-	for (k = 0; k <= i - 1; k++)
-		naked_path[k] = path[k];
-	naked_path[k] = '\0';
-}
-
 void game_click()
 {
 	if (current_settings->hide_side_panel || current_settings->hide_screenshots)
@@ -1277,21 +1244,6 @@ int get_genre(char* title, char* genre)
 	return 0;
 }
 
-void get_path(char* title, char* path)
-{
-	for (item_games = games; item_games != NULL; item_games = item_games->next)
-	{
-		if (item_games->deleted != 1)
-		{
-			if (!strcmp(title, item_games->title))
-			{
-				strcpy(path, item_games->path);
-				break;
-			}
-		}
-	}
-}
-
 /*
 * Adds a repository (path on the disk)
 * to the list of repositories
@@ -1363,33 +1315,6 @@ int title_exists(char* game_title)
 	}
 	// Title not found
 	return 0;
-}
-
-char* get_slave_from_path(char* slave, int start, char* path)
-{
-	int z = 0;
-	for (int k = start + 1; k <= strlen(path); k++)
-	{
-		slave[z] = path[k];
-		z++;
-	}
-	return slave;
-}
-
-/*
- * Check if a path actually exists in hard disk.
- * - Return True if exists
- * - Return False if it doesn't exist
- */
-int check_path_exists(char* path)
-{
-	const BPTR lock = Lock(path, ACCESS_READ);
-	if (!lock) {
-		return FALSE;
-	}
-
-	UnLock(lock);
-	return TRUE;
 }
 
 //shows and inits the GameProperties Window
@@ -2008,89 +1933,6 @@ void refresh_list(const int check_exists)
 	status_show_total();
 }
 
-BOOL get_filename(const char* title, const char* positive_text, const BOOL save_mode)
-{
-	BOOL result = FALSE;
-	if ((request = MUI_AllocAslRequest(ASL_FileRequest, NULL)) != NULL)
-	{
-		if (MUI_AslRequestTags(request,
-		                       ASLFR_TitleText, title,
-		                       ASLFR_PositiveText, positive_text,
-		                       ASLFR_DoSaveMode, save_mode,
-		                       ASLFR_InitialDrawer, PROGDIR,
-		                       TAG_DONE))
-		{
-			memset(&fname[0], 0, sizeof fname);
-			strcat(fname, request->fr_Drawer);
-			if (fname[strlen(fname) - 1] != (UBYTE)58) /* Check for : */
-				strcat(fname, "/");
-			strcat(fname, request->fr_File);
-
-			result = TRUE;
-		}
-
-		if (request)
-			MUI_FreeAslRequest(request);
-	}
-
-	return result;
-}
-
-void save_to_csv(const char* filename, const int check_exists)
-{
-	char csvFilename[32];
-	FILE *fpgames;
-
-	const char* saving_message = (const char*)GetMBString(MSG_SavingGamelist);
-	set(app->TX_Status, MUIA_Text_Contents, saving_message);
-
-	strcpy(csvFilename, (CONST_STRPTR)filename);
-	strcat(csvFilename, ".csv");
-
-	fpgames = fopen(csvFilename,"w");
-	if (!fpgames)
-	{
-		msg_box((const char*)GetMBString(MSG_FailedOpeningGameslist));
-		return;
-	}
-
-	for (item_games = games; item_games != NULL; item_games = item_games->next)
-	{
-		if (check_exists == 1)
-		{
-			if (item_games->exists == 1)
-			{
-				if (strlen(item_games->genre) == 0)
-					strcpy(item_games->genre, "Unknown");
-				fprintf(
-					fpgames,
-					"%d;%s;%s;%s;%d;%d;%d;%d\n",
-					item_games->index, item_games->title, item_games->genre, item_games->path,
-					item_games->favorite, item_games->times_played, item_games->last_played, item_games->hidden
-				);
-			}
-			else
-			{
-				strcpy(item_games->path, "");
-			}
-		}
-		else
-		{
-			if (strlen(item_games->genre) == 0)
-				strcpy(item_games->genre, "Unknown");
-			fprintf(
-				fpgames,
-				"%d;%s;%s;%s;%d;%d;%d;%d\n",
-				item_games->index, item_games->title, item_games->genre, item_games->path,
-				item_games->favorite, item_games->times_played, item_games->last_played, item_games->hidden
-			);
-		}
-	}
-	fclose(fpgames);
-
-	status_show_total();
-}
-
 void save_list(const int check_exists)
 {
 	save_to_csv(DEFAULT_GAMESLIST_FILE, check_exists);
@@ -2392,7 +2234,7 @@ void msg_box(const char* msg)
 	EasyRequest(NULL, &msgbox, NULL);
 }
 
-void get_screen_size(int* width, int* height)
+void get_screen_size(int *width, int *height)
 {
 	struct Screen* wbscreen;
 	struct Library* intuition_base;
@@ -2433,107 +2275,6 @@ void get_screen_size(int* width, int* height)
 			CloseLibrary(gfx_base);
 		}
 		CloseLibrary(intuition_base);
-	}
-}
-
-void read_tool_types()
-{
-	struct Library *icon_base;
-	struct DiskObject *disk_obj;
-
-	int screen_width, screen_height;
-	unsigned char filename[32];
-
-	if ((icon_base = (struct Library *)OpenLibrary((CONST_STRPTR)ICON_LIBRARY, 0)))
-	{
-		strcpy(filename, PROGDIR);
-		strcat(filename, executable_name);
-
-		if ((disk_obj = GetDiskObject((STRPTR)filename)))
-		{
-			if (FindToolType(disk_obj->do_ToolTypes, (STRPTR)TOOLTYPE_SCREENSHOT))
-			{
-				char** tool_types = (char **)disk_obj->do_ToolTypes;
-				char* tool_type = *tool_types;
-
-				char** temp_tbl = my_split((char *)tool_type, "=");
-				if (temp_tbl == NULL
-					|| temp_tbl[0] == NULL
-					|| !strcmp(temp_tbl[0], " ")
-					|| !strcmp(temp_tbl[0], ""))
-				{
-					msg_box((const char*)GetMBString(MSG_BadTooltype));
-					exit(0);
-				}
-
-				if (temp_tbl[1] != NULL)
-				{
-					char** temp_tbl2 = my_split((char *)temp_tbl[1], "x");
-					if (temp_tbl2[0]) current_settings->screenshot_width = atoi((char *)temp_tbl2[0]);
-					if (temp_tbl2[1]) current_settings->screenshot_height = atoi((char *)temp_tbl2[1]);
-
-					free(temp_tbl2[0]);
-					free(temp_tbl2[1]);
-					free(temp_tbl2);
-					free(temp_tbl[0]);
-					free(temp_tbl[1]);
-					free(temp_tbl);
-				}
-			}
-
-			if (FindToolType(disk_obj->do_ToolTypes, (STRPTR)TOOLTYPE_NOGUIGFX))
-				current_settings->no_guigfx = 1;
-
-			if (FindToolType(disk_obj->do_ToolTypes, (STRPTR)TOOLTYPE_FILTERUSEENTER))
-				current_settings->filter_use_enter = 1;
-
-			if (FindToolType(disk_obj->do_ToolTypes, (STRPTR)TOOLTYPE_NOSCREENSHOT))
-				current_settings->hide_screenshots = 1;
-
-			if (FindToolType(disk_obj->do_ToolTypes, (STRPTR)TOOLTYPE_SAVESTATSONEXIT))
-				current_settings->save_stats_on_exit = 1;
-
-			if (FindToolType(disk_obj->do_ToolTypes, (STRPTR)TOOLTYPE_TITLESFROMDIRS))
-				current_settings->titles_from_dirs = 1;
-
-			if (FindToolType(disk_obj->do_ToolTypes, (STRPTR)TOOLTYPE_NOSMARTSPACES))
-				current_settings->no_smart_spaces = 1;
-
-			if (FindToolType(disk_obj->do_ToolTypes, (STRPTR)TOOLTYPE_NOSIDEPANEL))
-				current_settings->hide_side_panel = 1;
-		}
-		CloseLibrary(icon_base);
-	}
-
-	if (!current_settings->hide_side_panel)
-	{
-		//check screen res and adjust image box accordingly
-		if (current_settings->screenshot_height <= 0 && current_settings->screenshot_width <= 0)
-		{
-			get_screen_size(&screen_width, &screen_height);
-
-			//if values are ok from the previous function, and user has not provided his own values, calculate a nice size
-			if (screen_width != -1 && screen_height != -1)
-			{
-				//for hi-res screens (1024x768 or greater) we'll use 320x256
-				if (screen_width >= 1024 && screen_height >= 768)
-				{
-					current_settings->screenshot_width = 320;
-					current_settings->screenshot_height = 256;
-				}
-				else
-				{
-					// for anything less, we'll go with half that
-					current_settings->screenshot_width = 160;
-					current_settings->screenshot_height = 128;
-				}
-			}
-			else
-			{
-				current_settings->screenshot_width = 160;
-				current_settings->screenshot_height = 128;
-			}
-		}
 	}
 }
 
@@ -2596,76 +2337,6 @@ void non_whdload_ok()
 }
 
 /*
-* Gets title from a slave file
-* returns 0 on success, 1 on fail
-*/
-int get_title_from_slave(char* slave, char* title)
-{
-	char slave_title[100];
-
-	struct slave_info
-	{
-		unsigned long security;
-		char id[8];
-		unsigned short version;
-		unsigned short flags;
-		unsigned long base_mem_size;
-		unsigned long exec_install;
-		unsigned short game_loader;
-		unsigned short current_dir;
-		unsigned short dont_cache;
-		char keydebug;
-		char keyexit;
-		unsigned long exp_mem;
-		unsigned short name;
-		unsigned short copy;
-		unsigned short info;
-	};
-
-	struct slave_info sl;
-
-	FILE* fp = fopen(slave, "rbe");
-	if (fp == NULL)
-	{
-		return 1;
-	}
-
-	//seek to +0x20
-	fseek(fp, 32, SEEK_SET);
-	fread(&sl, 1, sizeof sl, fp);
-
-	//sl.Version = (sl.Version>>8) | (sl.Version<<8);
-	//sl.name = (sl.name>>8) | (sl.name<<8);
-
-	//printf ("[%s] [%d]\n", sl.ID, sl.Version);
-
-	//sl.name holds the offset for the slave name
-	fseek(fp, sl.name + 32, SEEK_SET);
-	//title = calloc (1, 100);
-	//fread (title, 1, 100, fp);
-
-	if (sl.version < 10)
-	{
-		return 1;
-	}
-
-	for (int i = 0; i <= 99; i++)
-	{
-		slave_title[i] = fgetc(fp);
-		if (slave_title[i] == '\n')
-		{
-			slave_title[i] = '\0';
-			break;
-		}
-	}
-
-	strcpy(title, slave_title);
-	fclose(fp);
-
-	return 0;
-}
-
-/*
 * Checks if the title already exists
 * returns 1 if yes, 0 otherwise
 */
@@ -2679,70 +2350,6 @@ int check_dup_title(char* title)
 		}
 	}
 	return 0;
-}
-
-// Get the Directory part from a full path containing a file
-const char* get_directory_name(const char* str)
-{
-	int pos1 = get_delimiter_position(str);
-	if (!pos1)
-		return NULL;
-
-	char full_path[100];
-	strncpy(full_path, str, pos1);
-	full_path[pos1] = '\0';
-
-	const int pos2 = get_delimiter_position(full_path);
-	if (!pos2)
-		return NULL;
-
-	char* dir_name = malloc(sizeof full_path);
-	int c = 0;
-	for (unsigned int i = pos2 + 1; i <= sizeof full_path; i++)
-	{
-		dir_name[c] = full_path[i];
-		c++;
-	}
-	dir_name[c] = '\0';
-
-	return dir_name;
-}
-
-// Get the complete directory path from a full path containing a file
-const char *get_directory_path(const char *str)
-{
-	int pos1 = get_delimiter_position(str);
-	if (!pos1)
-		return NULL;
-
-	char *dir_name = malloc(pos1 + 1);
-	strncpy(dir_name, str, pos1);
-	dir_name[pos1] = '\0';
-
-	return dir_name;
-}
-
-// Get the application's executable name
-const char *get_executable_name(int argc, char **argv)
-{
-	// argc is zero when run from the Workbench,
-	// positive when run from the CLI
-	if (argc == 0)
-	{
-		// in AmigaOS, argv is a pointer to the WBStartup message
-		// when argc is zero (run under the Workbench)
-		struct WBStartup* argmsg = (struct WBStartup *)argv;
-		struct WBArg* wb_arg = argmsg->sm_ArgList; /* head of the arg list */
-
-		executable_name = wb_arg->wa_Name;
-	}
-	else
-	{
-		// Run from the CLI
-		executable_name = argv[0];
-	}
-
-	return executable_name;
 }
 
 void joy_left()
@@ -2832,44 +2439,4 @@ ULONG get_wb_version()
 	ver = WorkbenchBase->lib_Version;
 
 	return ver;
-}
-
-void open_current_dir()
-{
-	// Allocate Memory for variables
-	char *game_title = NULL;
-	const char *path_only = NULL;
-
-	if (get_wb_version() < 44)
-	{
-		// workbench.library doesn't support OpenWorkbenchObjectA yet
-		return;
-	}
-
-	//set the elements on the window
-	DoMethod(app->LV_GamesList, MUIM_List_GetEntry, MUIV_List_GetEntry_Active, &game_title);
-	if (game_title == NULL || strlen(game_title) == 0)
-	{
-		msg_box((const char*)GetMBString(MSG_SelectGameFromList));
-		return;
-	}
-
-	const int found = title_exists(game_title);
-	if (!found)
-	{
-		msg_box((const char*)GetMBString(MSG_SelectGameFromList));
-		return;
-	}
-
-	path_only = get_directory_path(item_games->path);
-	if(!path_only)
-	{
-		msg_box((const char*)GetMBString(MSG_DirectoryNotFound));
-		return;
-	}
-
-	//Open path directory
-	OpenWorkbenchObject((char *)path_only);
-	free(path_only); // get_directory_path uses malloc()
-
 }

--- a/src/funcs.h
+++ b/src/funcs.h
@@ -1,6 +1,6 @@
 /*
   iGameMain.c
-  String functions header for iGame
+  Misc functions header for iGame
 
   Copyright (c) 2018, Emmanuel Vasilakis
 
@@ -20,14 +20,12 @@
   along with iGame. If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef _STR_FUNCS_H
-#define _STR_FUNCS_H
+#ifndef _FUNCS_H
+#define _FUNCS_H
 
-char *strcasestr(const char *, const char *);
-char* strdup(const char *); // TODO: Possible obsolete. Maybe needed on some old tools. Better move it there
-void string_to_lower(char *);
-char** my_split(char *, char *);
-int get_delimiter_position(const char *);
-const char* add_spaces_to_string(const char *);
+void msg_box(const char *);
+void status_show_total(void);
+void get_screen_size(int *, int *);
+int title_exists(char *game_title);
 
 #endif

--- a/src/iGameExtern.h
+++ b/src/iGameExtern.h
@@ -149,7 +149,7 @@ void settings_use();
 const unsigned char* GetMBString(const unsigned char* ref);
 void joy_left();
 void joy_right();
-void open_current_dir();
+// void open_current_dir();
 ULONG get_wb_version();
 
 #endif

--- a/src/iGameGUI.c
+++ b/src/iGameGUI.c
@@ -58,7 +58,7 @@
 #include "iGameGUI.h"
 #include "iGameExtern.h"
 #include "iGame_cat.h"
-#include "version.h"
+#include "fsfuncs.h"
 
 extern igame_settings *current_settings;
 

--- a/src/strfuncs.c
+++ b/src/strfuncs.c
@@ -1,3 +1,24 @@
+/*
+  iGameMain.c
+  String functions source for iGame
+
+  Copyright (c) 2018, Emmanuel Vasilakis
+
+  This file is part of iGame.
+
+  iGame is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  iGame is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with iGame. If not, see <http://www.gnu.org/licenses/>.
+*/
 
 #include <ctype.h>
 #include <stdlib.h>


### PR DESCRIPTION
During the refactoring I do to clean up the huge funcs file and split it to smaller files, I created the fsfuncs.c to host in there all the filesystem methods. 
Added a funcs.h file to add methods that required to be used by other source files.
Also, removed not needed includes in fsfuncs.c and funcs.c.