### PR TITLE
Issue 162

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## iGame 2.1b3 - [future]
+### Added
+- Added a check if the screenshot image is supported by the installed datatypes. If not, it is skipped. This fixes situations where the Info datatype is not installed and no image is shown instead of the default.
+
 ### Changed
-- Gathered the string methods into one separate file. This is work that needs to be done so to make funcs.c smaller. Also merged the strcasestr.c and strdup.c files.
+- Gathered the strings methods into one separate file. This is work that needs to be done so to make funcs.c smaller. Also merged the strcasestr.c and strdup.c files.
+- Moved the filesystem methods to a separate file.
 
 ## iGame 2.1b2 - [2021-03-15]
 ### Added

--- a/src/fsfuncs.c
+++ b/src/fsfuncs.c
@@ -61,6 +61,7 @@
 
 extern struct ObjApp* app;
 extern char* executable_name;
+extern const int MAX_PATH_SIZE;
 
 /* structures */
 struct FileRequester* request;
@@ -70,7 +71,7 @@ extern char fname[255];
 extern games_list *item_games, *games;
 extern igame_settings *current_settings;
 
-
+// TODO: This is obsolete. Change it with getParentPath()
 void strip_path(const char *path, char *naked_path)
 {
 	int i, k;
@@ -84,6 +85,26 @@ void strip_path(const char *path, char *naked_path)
 	for (k = 0; k <= i - 1; k++)
 		naked_path[k] = path[k];
 	naked_path[k] = '\0';
+}
+
+STRPTR getParentPath(STRPTR filename)
+{
+	STRPTR path = AllocVec(sizeof(char) * MAX_PATH_SIZE, MEMF_CLEAR);
+	if (path)
+	{
+		BPTR fileLock = Lock(filename, ACCESS_READ);
+		if (fileLock)
+		{
+			BPTR folderLock = ParentDir(fileLock);
+			NameFromLock(folderLock, path, sizeof(char) * MAX_PATH_SIZE);
+
+			UnLock(folderLock);
+			UnLock(fileLock);
+			return path;
+		}
+	}
+
+	return NULL;
 }
 
 char* get_slave_from_path(char *slave, int start, char *path)
@@ -102,15 +123,15 @@ char* get_slave_from_path(char *slave, int start, char *path)
  * - Return True if exists
  * - Return False if it doesn't exist
  */
-int check_path_exists(char *path)
+BOOL check_path_exists(char *path)
 {
 	const BPTR lock = Lock(path, ACCESS_READ);
-	if (!lock) {
-		return FALSE;
+	if (lock) {
+		UnLock(lock);
+		return TRUE;
 	}
 
-	UnLock(lock);
-	return TRUE;
+	return FALSE;
 }
 
 BOOL get_filename(const char *title, const char *positive_text, const BOOL save_mode)
@@ -204,6 +225,7 @@ void read_tool_types(void)
 	int screen_width, screen_height;
 	unsigned char filename[32];
 
+	// TODO: The opening and the close of the library needs to be done at application start and end
 	if ((icon_base = (struct Library *)OpenLibrary((CONST_STRPTR)ICON_LIBRARY, 0)))
 	{
 		strcpy(filename, PROGDIR);
@@ -367,6 +389,7 @@ int get_title_from_slave(char* slave, char* title)
 	return 0;
 }
 
+// TODO: This seems OBSOLETE and can be replaced by getParentPath(). Needs investigation
 // Get the Directory part from a full path containing a file
 const char* get_directory_name(const char* str)
 {
@@ -394,6 +417,7 @@ const char* get_directory_name(const char* str)
 	return dir_name;
 }
 
+// TODO: This seems OBSOLETE and can be replaced by getParentPath(). Needs investigation
 // Get the complete directory path from a full path containing a file
 const char *get_directory_path(const char *str)
 {
@@ -431,6 +455,7 @@ const char *get_executable_name(int argc, char **argv)
 	return executable_name;
 }
 
+// TODO: This can use the getParentPath()
 void open_current_dir(void)
 {
 	// Allocate Memory for variables

--- a/src/fsfuncs.h
+++ b/src/fsfuncs.h
@@ -23,9 +23,10 @@
 #ifndef _FS_FUNCS_H
 #define _FS_FUNCS_H
 
+STRPTR getParentPath(STRPTR);
 void strip_path(const char *, char *);
 char *get_slave_from_path(char *, int, char *);
-int check_path_exists(char *);
+BOOL check_path_exists(char *);
 BOOL get_filename(const char *, const char *, const BOOL);
 void save_to_csv(const char *, const int);
 void read_tool_types(void);

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -26,6 +26,7 @@
 #include <mui/TextEditor_mcc.h>
 
 /* Prototypes */
+#include <clib/alib_protos.h>
 #include <proto/wb.h>
 
 #if defined(__amigaos4__)
@@ -1113,29 +1114,36 @@ void refresh_sidepanel()
 
 static void show_screenshot(STRPTR screenshot_path)
 {
-	if (current_settings->no_guigfx)
-	{
-		app->IM_GameImage_1 = MUI_NewObject(Dtpic_Classname,
-					MUIA_Dtpic_Name,		screenshot_path,
-					MUIA_Frame, 				MUIV_Frame_ImageButton,
-		End;
-	}
-	else
-	{
-		app->IM_GameImage_1 = GuigfxObject,
-					MUIA_Guigfx_FileName,				screenshot_path,
-					MUIA_Guigfx_Quality,				MUIV_Guigfx_Quality_Best,
-					MUIA_Guigfx_ScaleMode,			NISMF_SCALEFREE | NISMF_KEEPASPECT_PICTURE,
-					MUIA_Guigfx_Transparency,		0,
-					MUIA_Frame, 								MUIV_Frame_ImageButton,
-					MUIA_FixHeight, 						current_settings->screenshot_height,
-					MUIA_FixWidth, 							current_settings->screenshot_width,
-		End;
-	}
+	static char prvScreenshot[255];
 
-	if (app->IM_GameImage_1)
+	if (strcmp(screenshot_path, prvScreenshot))
 	{
-		refresh_sidepanel();
+		if (current_settings->no_guigfx)
+		{
+			app->IM_GameImage_1 = MUI_NewObject(Dtpic_Classname,
+						MUIA_Dtpic_Name,		screenshot_path,
+						MUIA_Frame, 				MUIV_Frame_ImageButton,
+			End;
+		}
+		else
+		{
+			app->IM_GameImage_1 = GuigfxObject,
+						MUIA_Guigfx_FileName,				screenshot_path,
+						MUIA_Guigfx_Quality,				MUIV_Guigfx_Quality_Best,
+						MUIA_Guigfx_ScaleMode,			NISMF_SCALEFREE | NISMF_KEEPASPECT_PICTURE,
+						MUIA_Guigfx_Transparency,		0,
+						MUIA_Frame, 								MUIV_Frame_ImageButton,
+						MUIA_FixHeight, 						current_settings->screenshot_height,
+						MUIA_FixWidth, 							current_settings->screenshot_width,
+			End;
+		}
+
+		if (app->IM_GameImage_1)
+		{
+			refresh_sidepanel();
+		}
+
+		strcpy(prvScreenshot, screenshot_path);
 	}
 }
 
@@ -1170,17 +1178,15 @@ static char *get_screenshot_path(char *game_title)
 	// Return the igame.iff from the game folder, if exists
 	snprintf(screenshot_path, sizeof(char) * MAX_PATH_SIZE, "%s/igame.iff", slavePath);
 	FreeVec(slavePath);
-
-	if(check_path_exists(screenshot_path))
+	if(check_path_exists(screenshot_path) && checkImageDatatype(screenshot_path))
 	{
 		FreeVec(path);
 		return screenshot_path;
 	}
 
 	// Return the slave icon from the game folder, if exists
-	// TODO: Check if .info datatype exists before use this one, otherwise ignore
 	snprintf(screenshot_path, sizeof(char) * MAX_PATH_SIZE, "%s.info", substring(path, 0, -6));
-	if(check_path_exists(screenshot_path))
+	if(check_path_exists(screenshot_path) && checkImageDatatype(screenshot_path))
 	{
 		FreeVec(path);
 		return screenshot_path;

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -73,6 +73,7 @@ char* game_tooltypes;
 char fname[255];
 int IntroPic = 0;
 int wbrun = 0;
+const int MAX_PATH_SIZE = 255;
 
 /* function definitions */
 int get_genre(char* title, char* genre);
@@ -1110,118 +1111,113 @@ void refresh_sidepanel()
 	DoMethod(app->GR_sidepanel, MUIM_Group_ExitChange);
 }
 
-void game_click()
+static void show_screenshot(STRPTR screenshot_path)
+{
+	if (current_settings->no_guigfx)
+	{
+		app->IM_GameImage_1 = MUI_NewObject(Dtpic_Classname,
+					MUIA_Dtpic_Name,		screenshot_path,
+					MUIA_Frame, 				MUIV_Frame_ImageButton,
+		End;
+	}
+	else
+	{
+		app->IM_GameImage_1 = GuigfxObject,
+					MUIA_Guigfx_FileName,				screenshot_path,
+					MUIA_Guigfx_Quality,				MUIV_Guigfx_Quality_Best,
+					MUIA_Guigfx_ScaleMode,			NISMF_SCALEFREE | NISMF_KEEPASPECT_PICTURE,
+					MUIA_Guigfx_Transparency,		0,
+					MUIA_Frame, 								MUIV_Frame_ImageButton,
+					MUIA_FixHeight, 						current_settings->screenshot_height,
+					MUIA_FixWidth, 							current_settings->screenshot_width,
+		End;
+	}
+
+	if (app->IM_GameImage_1)
+	{
+		refresh_sidepanel();
+	}
+}
+
+static char *get_screenshot_path(char *game_title)
+{
+	STRPTR path = AllocVec(sizeof(char) * MAX_PATH_SIZE, MEMF_CLEAR);
+	if(path == NULL)
+	{
+		msg_box((const char*)GetMBString(MSG_NotEnoughMemory));
+		return NULL;
+	}
+	get_path(game_title, path);
+
+	STRPTR slavePath = AllocVec(sizeof(char) * MAX_PATH_SIZE, MEMF_CLEAR);
+	if(slavePath == NULL)
+	{
+		msg_box((const char*)GetMBString(MSG_NotEnoughMemory));
+		FreeVec(path);
+		return NULL;
+	}
+	strcpy(slavePath, getParentPath(path));
+
+	STRPTR screenshot_path = AllocVec(sizeof(char) * MAX_PATH_SIZE, MEMF_CLEAR);
+	if (screenshot_path == NULL)
+	{
+		msg_box((const char*)GetMBString(MSG_NotEnoughMemory));
+		FreeVec(path);
+		FreeVec(slavePath);
+		return NULL;
+	}
+
+	// Return the igame.iff from the game folder, if exists
+	snprintf(screenshot_path, sizeof(char) * MAX_PATH_SIZE, "%s/igame.iff", slavePath);
+	FreeVec(slavePath);
+
+	if(check_path_exists(screenshot_path))
+	{
+		FreeVec(path);
+		return screenshot_path;
+	}
+
+	// Return the slave icon from the game folder, if exists
+	// TODO: Check if .info datatype exists before use this one, otherwise ignore
+	snprintf(screenshot_path, sizeof(char) * MAX_PATH_SIZE, "%s.info", substring(path, 0, -6));
+	if(check_path_exists(screenshot_path))
+	{
+		FreeVec(path);
+		return screenshot_path;
+	}
+
+	// Return the default image from iGame folder, if exists
+	if(check_path_exists(DEFAULT_SCREENSHOT_FILE))
+	{
+		FreeVec(path);
+		return DEFAULT_SCREENSHOT_FILE;
+	}
+
+	FreeVec(path);
+	return NULL;
+}
+
+void game_click(void)
 {
 	if (current_settings->hide_side_panel || current_settings->hide_screenshots)
 		return;
 
-	char* game_title = NULL;
+	char *game_title = NULL;
 	DoMethod(app->LV_GamesList, MUIM_List_GetEntry, MUIV_List_GetEntry_Active, &game_title);
 
 	if (game_title) //for some reason, game_click is called and game_title is null??
 	{
-		char* path = malloc(256 * sizeof(char));
-		if (path != NULL)
-			get_path(game_title, path);
-		else
+		STRPTR image_path = AllocVec(sizeof(char) * MAX_PATH_SIZE, MEMF_CLEAR);
+		if(image_path == NULL)
 		{
 			msg_box((const char*)GetMBString(MSG_NotEnoughMemory));
 			return;
 		}
 
-		char* naked_path = malloc(300 * sizeof(char));
-		if (naked_path != NULL)
-			strip_path(path, naked_path);
-		else
+		strcpy(image_path, get_screenshot_path(game_title));
+		if (strcmp(image_path, ""))
 		{
-			msg_box((const char*)GetMBString(MSG_NotEnoughMemory));
-			return;
-		}
-
-		//Check the string, when filter is populated there is trouble
-		if (strlen(naked_path) != 0)
-		{
-			sprintf(naked_path, "%s/igame.iff", (const char*)naked_path);
-			BPTR fp = Open((CONST_STRPTR)naked_path, MODE_OLDFILE);
-			if (!fp) //no igame.iff, try .info and newicons
-			{
-				if (strcasestr(path, ".slave")) //check for whdload game
-				{
-					path[strlen(path) - 6] = '\0';
-					sprintf(naked_path, "%s.info", (const char*)path);
-					fp = Open((CONST_STRPTR)naked_path, MODE_OLDFILE);
-				}
-			}
-
-			if (fp)
-			{
-				// We don't need the file open anymore
-				Close(fp);
-
-				if (current_settings->no_guigfx)
-				{
-					app->IM_GameImage_1 = MUI_NewObject(Dtpic_Classname,
-					                                    MUIA_Dtpic_Name, naked_path,
-					                                    MUIA_Frame, MUIV_Frame_ImageButton,
-					End;
-				}
-				else
-				{
-					app->IM_GameImage_1 = GuigfxObject, MUIA_Guigfx_FileName, naked_path,
-					                                  MUIA_Guigfx_Quality, MUIV_Guigfx_Quality_Best,
-					                                  MUIA_Guigfx_ScaleMode, NISMF_SCALEFREE | NISMF_KEEPASPECT_PICTURE,
-					                                  MUIA_Guigfx_Transparency, 0,
-					                                  MUIA_Frame, MUIV_Frame_ImageButton,
-					                                  MUIA_FixHeight, current_settings->screenshot_height,
-					                                  MUIA_FixWidth, current_settings->screenshot_width,
-					End;
-				}
-
-				if (app->IM_GameImage_1)
-				{
-					refresh_sidepanel();
-					IntroPic = 0;
-				}
-				else
-					//in case it failed to load something, lets hope it gets picked up here and is forced to load the default igame.iff
-				{
-					goto loaddef;
-				}
-			}
-			else //no pic found
-			{
-			loaddef:
-				if (IntroPic == 0)
-				{
-					if (current_settings->no_guigfx)
-					{
-						app->IM_GameImage_1 = (Object *)MUI_NewObject(Dtpic_Classname,
-						                                              MUIA_Dtpic_Name, DEFAULT_SCREENSHOT_FILE,
-						                                              MUIA_Frame, MUIV_Frame_ImageButton,
-						End;
-					}
-					else
-					{
-						app->IM_GameImage_1 = GuigfxObject, MUIA_Guigfx_FileName, DEFAULT_SCREENSHOT_FILE,
-						                                  MUIA_Guigfx_Quality, MUIV_Guigfx_Quality_Best,
-						                                  MUIA_Guigfx_ScaleMode, NISMF_SCALEFREE | NISMF_KEEPASPECT_PICTURE,
-						                                  MUIA_Guigfx_Transparency, 0,
-						                                  MUIA_Frame, MUIV_Frame_ImageButton,
-						                                  MUIA_FixHeight, current_settings->screenshot_height,
-						                                  MUIA_FixWidth, current_settings->screenshot_width,
-						End;
-					}
-					if (app->IM_GameImage_1)
-					{
-						refresh_sidepanel();
-						IntroPic = 1;
-					}
-				}
-			}
-			if (path)
-				free(path);
-			if (naked_path)
-				free(naked_path);
+			show_screenshot(image_path);
 		}
 	}
 }

--- a/src/funcs.h
+++ b/src/funcs.h
@@ -27,5 +27,6 @@ void msg_box(const char *);
 void status_show_total(void);
 void get_screen_size(int *, int *);
 int title_exists(char *game_title);
+void game_click(void);
 
 #endif

--- a/src/iGameExtern.h
+++ b/src/iGameExtern.h
@@ -129,7 +129,6 @@ void list_show_hidden();
 void app_start();
 void game_properties();
 void add_non_whdload();
-void game_click();
 void genres_click();
 void non_whdload_ok();
 void repo_stop();
@@ -149,7 +148,6 @@ void settings_use();
 const unsigned char* GetMBString(const unsigned char* ref);
 void joy_left();
 void joy_right();
-// void open_current_dir();
 ULONG get_wb_version();
 
 #endif

--- a/src/iGameGUI.c
+++ b/src/iGameGUI.c
@@ -32,6 +32,7 @@
 #include <proto/exec.h>
 #include <proto/icon.h>
 #include <proto/asl.h>
+#include <proto/datatypes.h>
 #include <proto/muimaster.h>
 
 /* System */
@@ -1599,4 +1600,19 @@ void DisposeApp(struct ObjApp * object)
 		MUI_DisposeObject(object->App);
 		FreeVec(object);
 	}
+}
+
+BOOL checkImageDatatype(STRPTR filename)
+{
+	Object *dtObj = NewDTObject(filename,
+			DTA_GroupID,	GID_PICTURE,
+			TAG_DONE);
+
+	if (dtObj)
+	{
+		DisposeDTObject (dtObj);
+		return TRUE;
+	}
+
+	return FALSE;
 }

--- a/src/iGameGUI.c
+++ b/src/iGameGUI.c
@@ -55,10 +55,11 @@
 #endif
 
 #include "version.h"
-#include "iGameGUI.h"
 #include "iGameExtern.h"
 #include "iGame_cat.h"
 #include "fsfuncs.h"
+#include "funcs.h"
+#include "iGameGUI.h"
 
 extern igame_settings *current_settings;
 

--- a/src/iGameGUI.h
+++ b/src/iGameGUI.h
@@ -98,4 +98,6 @@ struct ObjApp
 extern struct ObjApp* CreateApp(void);
 extern void DisposeApp(struct ObjApp*);
 
+BOOL checkImageDatatype(STRPTR);
+
 #endif

--- a/src/strfuncs.c
+++ b/src/strfuncs.c
@@ -20,6 +20,8 @@
   along with iGame. If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <proto/wb.h>
+
 #include <ctype.h>
 #include <stdlib.h>
 #include <string.h>
@@ -192,4 +194,29 @@ const char* add_spaces_to_string(const char* input)
 	output[output_index] = '\0';
 
 	return output;
+}
+
+STRPTR substring(STRPTR string, int position, int length)
+{
+	STRPTR p;
+	size_t c;
+	if (position < 0) position = 0;
+	if (length < 0) length = strlen(string) + length;
+
+	p = malloc(length+1);
+
+	if (p == NULL)
+	{
+		return NULL;
+	}
+
+	for (c = 0; c < length; c++)
+	{
+		*(p+c) = *(string + position);
+		string++;
+	}
+
+	*(p+c) = '\0';
+
+	return p;
 }

--- a/src/strfuncs.h
+++ b/src/strfuncs.h
@@ -29,5 +29,6 @@ void string_to_lower(char *);
 char** my_split(char *, char *);
 int get_delimiter_position(const char *);
 const char* add_spaces_to_string(const char *);
+STRPTR substring(STRPTR, int, int);
 
 #endif


### PR DESCRIPTION
In this PR:
- I made some fixes on funcs.c which were not synced right after the previous PRs
- Fixed the #162 where I check if a screenshot is supported by the installed Datatypes. If not, the image is skipped, moving to the next check. This fixes the situation where a user doesn't have Info datatype installed and an empty screenshot is shown. Now it skips that and moves to show the default image from iGame folder.
- Added a check if the screenshot is already visible. In that case it doesn't show that image again. This helps in situations where always the default image is shown because of lack of screenshots.