### PR TITLE
/* Add quotes to Execute.... ToolTypes for WHDLoad compatibility */

### DIFF
--- a/src/funcs.c
+++ b/src/funcs.c
@@ -942,6 +942,19 @@ void launch_game(void)
 								if (tool_type[0] == '#') continue;
 								if (tool_type[0] == '!') continue;
 
+							    /* Add quotes to Execute.... ToolTypes for WHDLoad compatibility */
+							    if (!strncmp(tool_type, "Execute", 7))
+							    {
+									char** temp_tbl = my_split((char *)tool_type, "=");
+									if (temp_tbl == NULL) continue;
+									if (temp_tbl[1] != NULL)
+									{
+										sprintf(tool_type,"%s=\"%s\"", temp_tbl[0],temp_tbl[1]);
+									}
+								    if (temp_tbl)
+										free(temp_tbl);
+								}
+
 								/* Must check here for numerical values */
 								/* Those (starting with $ should be transformed to dec from hex) */
 								char** temp_tbl = my_split((char *)tool_type, "=");


### PR DESCRIPTION
Hi George,

You had a recent conversation with TuKo about iGame and WHDLoad ExecutePostDisk and similar ToolTypes.
Current iGame needs quotes used in the Execute..... ToolTypes to pass correctly to WHDLoad.
But using quotes means that double-clicking on WHDLoad icon will not work, as WHDLoad does not expect quotes when started from WB from icon.

So to make sure that both methods work, I would propose this change to add quotes automatically on the Execute.... ToolTypes.

This means users can define the Execute... ToolTypes according to WHDLoad standards (without quotes) and keep compatibility with starting WHDLoad game by WB icon, whilst using their favourite iGame.

Thanks for your great work on Amiga.

Greetings from Apollo Team

Willem Drijver  